### PR TITLE
Fix nullable reference type errors breaking CI build

### DIFF
--- a/src/StateMaker.Tests/StateTests.cs
+++ b/src/StateMaker.Tests/StateTests.cs
@@ -35,7 +35,7 @@ public class StateTests
         var state = new State();
         state.Variables["active"] = true;
 
-        Assert.True((bool)state.Variables["active"]);
+        Assert.True((bool)state.Variables["active"]!);
     }
 
     [Fact]
@@ -68,7 +68,7 @@ public class StateTests
         Assert.Equal(4, state.Variables.Count);
         Assert.Equal("Bob", state.Variables["name"]);
         Assert.Equal(30, state.Variables["age"]);
-        Assert.False((bool)state.Variables["active"]);
+        Assert.False((bool)state.Variables["active"]!);
         Assert.Equal(95.5, state.Variables["score"]);
     }
 
@@ -123,7 +123,7 @@ public class StateTests
         Assert.Equal(3, clone.Variables.Count);
         Assert.Equal("Alice", clone.Variables["name"]);
         Assert.Equal(30, clone.Variables["age"]);
-        Assert.True((bool)clone.Variables["active"]);
+        Assert.True((bool)clone.Variables["active"]!);
     }
 
     [Fact]

--- a/src/StateMaker/State.cs
+++ b/src/StateMaker/State.cs
@@ -2,7 +2,7 @@ namespace StateMaker;
 
 public class State : IEquatable<State>
 {
-    public Dictionary<string, object> Variables { get; } = new();
+    public Dictionary<string, object?> Variables { get; } = new();
 
     public State Clone()
     {


### PR DESCRIPTION
## Summary
- Changed State.Variables from Dictionary<string, object> to Dictionary<string, object?> to properly support null variable values
- Added null-forgiving operator on bool unboxing casts in StateTests.cs to resolve CS8605 warnings promoted to errors by --warnaserror
- Fixes 4 CS8625/CS8605 errors that were failing CI since the State equality/hashing commits

## Test plan
- [x] dotnet build --configuration Release --warnaserror passes with 0 errors, 0 warnings
- [x] All 52 tests pass
- [ ] CI pipeline passes on this PR