### PR TITLE
Add StateMachineBuilder with BFS exploration and cycle detection

### DIFF
--- a/src/StateMaker.Tests/StateMachineBuilderTests.cs
+++ b/src/StateMaker.Tests/StateMachineBuilderTests.cs
@@ -2,16 +2,19 @@ namespace StateMaker.Tests;
 
 public class StateMachineBuilderTests
 {
-    private sealed class StubRule : IRule
+    private sealed class TestRule : IRule
     {
-        public bool IsAvailable(State state) => false;
-        public State Execute(State state) => state.Clone();
-    }
+        private readonly Func<State, bool> _isAvailable;
+        private readonly Func<State, State> _execute;
 
-    private sealed class AlwaysAvailableRule : IRule
-    {
-        public bool IsAvailable(State state) => true;
-        public State Execute(State state) => state.Clone();
+        public TestRule(Func<State, bool> isAvailable, Func<State, State> execute)
+        {
+            _isAvailable = isAvailable;
+            _execute = execute;
+        }
+
+        public bool IsAvailable(State state) => _isAvailable(state);
+        public State Execute(State state) => _execute(state);
     }
 
     [Fact]
@@ -19,7 +22,7 @@ public class StateMachineBuilderTests
     {
         var builder = new StateMachineBuilder();
         var initialState = new State();
-        var rules = new IRule[] { new StubRule() };
+        var rules = new IRule[] { new TestRule(_ => false, s => s.Clone()) };
         var config = new BuilderConfig();
 
         StateMachine result = builder.Build(initialState, rules, config);
@@ -33,7 +36,7 @@ public class StateMachineBuilderTests
         var builder = new StateMachineBuilder();
         var initialState = new State();
         initialState.Variables["status"] = "start";
-        var rules = new IRule[] { new StubRule() };
+        var rules = new IRule[] { new TestRule(_ => false, s => s.Clone()) };
         var config = new BuilderConfig();
 
         StateMachine result = builder.Build(initialState, rules, config);
@@ -47,7 +50,7 @@ public class StateMachineBuilderTests
     {
         var builder = new StateMachineBuilder();
         var initialState = new State();
-        var rules = new IRule[] { new StubRule() };
+        var rules = new IRule[] { new TestRule(_ => false, s => s.Clone()) };
         var config = new BuilderConfig();
 
         StateMachine result = builder.Build(initialState, rules, config);
@@ -61,7 +64,7 @@ public class StateMachineBuilderTests
     {
         var builder = new StateMachineBuilder();
         var initialState = new State();
-        var rules = new IRule[] { new StubRule() };
+        var rules = new IRule[] { new TestRule(_ => false, s => s.Clone()) };
         var config = new BuilderConfig();
 
         StateMachine result = builder.Build(initialState, rules, config);
@@ -75,7 +78,7 @@ public class StateMachineBuilderTests
     {
         var builder = new StateMachineBuilder();
         var initialState = new State();
-        var rules = new IRule[] { new StubRule() };
+        var rules = new IRule[] { new TestRule(_ => false, s => s.Clone()) };
         var config = new BuilderConfig();
 
         StateMachine result = builder.Build(initialState, rules, config);
@@ -89,7 +92,7 @@ public class StateMachineBuilderTests
     {
         var builder = new StateMachineBuilder();
         var initialState = new State();
-        var rules = new IRule[] { new AlwaysAvailableRule() };
+        var rules = new IRule[] { new TestRule(_ => true, s => s.Clone()) };
         var config = new BuilderConfig();
 
         StateMachine result = builder.Build(initialState, rules, config);
@@ -98,4 +101,31 @@ public class StateMachineBuilderTests
         Assert.Single(result.Transitions);
     }
 
+    [Fact]
+    public void Build_ShouldBeTwoStatesBecauseRuleMadeNewState()
+    {
+        var builder = new StateMachineBuilder();
+        var initialState = new State();
+        initialState.Variables["status"] = "Initial";
+        var rules = new IRule[] { new TestRule(
+            _ => true,
+            s => { var c = s.Clone(); c.Variables["status"] = "NewValue"; return c; })
+        };
+        var config = new BuilderConfig();
+
+        StateMachine result = builder.Build(initialState, rules, config);
+
+        Assert.Equal(2, result.States.Count);
+
+        var firstState = result.States[result.StartingStateId!];
+        Assert.Equal("Initial", firstState.Variables["status"]);
+
+        var secondStateEntry = result.States.First(kvp => kvp.Key != result.StartingStateId);
+        Assert.Single(secondStateEntry.Value.Variables);
+        Assert.Equal("NewValue", secondStateEntry.Value.Variables["status"]);
+
+        Assert.Contains(result.Transitions, t =>
+            t.SourceStateId == result.StartingStateId &&
+            t.TargetStateId == secondStateEntry.Key);
+    }
 }

--- a/src/StateMaker.Tests/StateMachineBuilderTests.cs
+++ b/src/StateMaker.Tests/StateMachineBuilderTests.cs
@@ -1,0 +1,101 @@
+namespace StateMaker.Tests;
+
+public class StateMachineBuilderTests
+{
+    private sealed class StubRule : IRule
+    {
+        public bool IsAvailable(State state) => false;
+        public State Execute(State state) => state.Clone();
+    }
+
+    private sealed class AlwaysAvailableRule : IRule
+    {
+        public bool IsAvailable(State state) => true;
+        public State Execute(State state) => state.Clone();
+    }
+
+    [Fact]
+    public void Build_ReturnsStateMachine()
+    {
+        var builder = new StateMachineBuilder();
+        var initialState = new State();
+        var rules = new IRule[] { new StubRule() };
+        var config = new BuilderConfig();
+
+        StateMachine result = builder.Build(initialState, rules, config);
+
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public void Build_InitialState_IsInStateMachine()
+    {
+        var builder = new StateMachineBuilder();
+        var initialState = new State();
+        initialState.Variables["status"] = "start";
+        var rules = new IRule[] { new StubRule() };
+        var config = new BuilderConfig();
+
+        StateMachine result = builder.Build(initialState, rules, config);
+
+        Assert.Single(result.States);
+        Assert.Equal(initialState, result.States.Values.First());
+    }
+
+    [Fact]
+    public void Build_SetsStartingStateId()
+    {
+        var builder = new StateMachineBuilder();
+        var initialState = new State();
+        var rules = new IRule[] { new StubRule() };
+        var config = new BuilderConfig();
+
+        StateMachine result = builder.Build(initialState, rules, config);
+
+        Assert.NotNull(result.StartingStateId);
+        Assert.True(result.States.ContainsKey(result.StartingStateId!));
+    }
+
+    [Fact]
+    public void Build_OnlyOneStateBecauseRuleReturnsCloneOfInitialState()
+    {
+        var builder = new StateMachineBuilder();
+        var initialState = new State();
+        var rules = new IRule[] { new StubRule() };
+        var config = new BuilderConfig();
+
+        StateMachine result = builder.Build(initialState, rules, config);
+
+        Assert.NotNull(result.StartingStateId);
+        Assert.Single(result.States);
+    }
+
+    [Fact]
+    public void Build_ShouldBeZeroTransitionsBecauseRuleReturnedFalseOnAvailable()
+    {
+        var builder = new StateMachineBuilder();
+        var initialState = new State();
+        var rules = new IRule[] { new StubRule() };
+        var config = new BuilderConfig();
+
+        StateMachine result = builder.Build(initialState, rules, config);
+
+        Assert.NotNull(result.StartingStateId);
+        Assert.Empty(result.Transitions);
+    }
+
+    [Fact]
+    public void Build_ShouldBeOneTransitionsBecauseRuleReturnedTrueOnAvailable()
+    {
+        var builder = new StateMachineBuilder();
+        var initialState = new State();
+        var rules = new IRule[] { new AlwaysAvailableRule() };
+        var config = new BuilderConfig();
+
+        StateMachine result = builder.Build(initialState, rules, config);
+
+        Assert.NotNull(result.StartingStateId);
+        Assert.Single(result.Transitions);
+    }
+
+}

--- a/src/StateMaker/IStateMachineBuilder.cs
+++ b/src/StateMaker/IStateMachineBuilder.cs
@@ -1,0 +1,6 @@
+namespace StateMaker;
+
+public interface IStateMachineBuilder
+{
+    StateMachine Build(State initialState, IRule[] rules, BuilderConfig config);
+}

--- a/src/StateMaker/StateMachineBuilder.cs
+++ b/src/StateMaker/StateMachineBuilder.cs
@@ -1,0 +1,51 @@
+namespace StateMaker;
+
+public class StateMachineBuilder : IStateMachineBuilder
+{
+    public StateMachine Build(State initialState, IRule[] rules, BuilderConfig config)
+    {
+        var stateMachine = new StateMachine();
+        var visited = new HashSet<State>();
+        var stateToId = new Dictionary<State, string>();
+        var queue = new Queue<(string id, State state)>();
+        int stateCounter = 0;
+
+        string initialId = $"S{stateCounter++}";
+        stateMachine.AddState(initialId, initialState);
+        stateMachine.StartingStateId = initialId;
+        visited.Add(initialState);
+        stateToId[initialState] = initialId;
+        queue.Enqueue((initialId, initialState));
+
+        while (queue.Count > 0)
+        {
+            var (currentId, currentState) = queue.Dequeue();
+
+            foreach (var rule in rules)
+            {
+                if (rule.IsAvailable(currentState))
+                {
+                    var newState = rule.Execute(currentState);
+                    string ruleName = rule.GetType().Name;
+
+                    if (visited.Contains(newState))
+                    {
+                        string existingId = stateToId[newState];
+                        stateMachine.Transitions.Add(new Transition(currentId, existingId, ruleName));
+                    }
+                    else
+                    {
+                        string newId = $"S{stateCounter++}";
+                        stateMachine.AddState(newId, newState);
+                        visited.Add(newState);
+                        stateToId[newState] = newId;
+                        stateMachine.Transitions.Add(new Transition(currentId, newId, ruleName));
+                        queue.Enqueue((newId, newState));
+                    }
+                }
+            }
+        }
+
+        return stateMachine;
+    }
+}

--- a/tasks/tasks-state-machine-builder.md
+++ b/tasks/tasks-state-machine-builder.md
@@ -80,14 +80,14 @@ All tests must pass before moving on to the next sub-task.
   - [x] 2.11 Write unit tests for BuilderConfig default values and Transition properties
 
 - [ ] 3.0 Implement StateMachineBuilder with BFS/DFS exploration and cycle detection
-  - [ ] 3.1 Define `IStateMachineBuilder` interface with `StateMachine Build(State initialState, IRule[] rules, BuilderConfig config)` method
-  - [ ] 3.2 Implement `StateMachineBuilder` class with BFS exploration: use a queue of states, apply all available rules to each state
-  - [ ] 3.3 Implement cycle detection using `HashSet<State>` — skip exploration when an equivalent state already exists, but still record the transition
-  - [ ] 3.4 Implement sequential state ID generation (S0, S1, S2, ...)
+  - [x] 3.1 Define `IStateMachineBuilder` interface with `StateMachine Build(State initialState, IRule[] rules, BuilderConfig config)` method
+  - [x] 3.2 Implement `StateMachineBuilder` class with BFS exploration: use a queue of states, apply all available rules to each state
+  - [x] 3.3 Implement cycle detection using `HashSet<State>` — skip exploration when an equivalent state already exists, but still record the transition
+  - [x] 3.4 Implement sequential state ID generation (S0, S1, S2, ...)
   - [ ] 3.5 Implement `MaxDepth` limit: track depth per state and stop exploring paths beyond the configured depth
   - [ ] 3.6 Implement `MaxStates` limit: stop adding new states once the limit is reached
   - [ ] 3.7 Implement DFS exploration strategy as an alternative to BFS (selected via `BuilderConfig.ExplorationStrategy`)
-  - [ ] 3.8 Derive rule names automatically from the rule class name (or allow configurable names)
+  - [x] 3.8 Derive rule names automatically from the rule class name (or allow configurable names)
   - [ ] 3.9 Write unit tests: simple linear state chain, branching states, cycle detection, depth limit respected, state count limit respected, BFS vs DFS ordering
   - [ ] 3.10 Write unit tests: no rules available (returns single-state machine), all rules always available, rules that produce duplicate states
 


### PR DESCRIPTION
## Summary
- Implement IStateMachineBuilder interface and StateMachineBuilder class
- BFS exploration using a queue, applying all available rules to each state
- Cycle detection via HashSet - skips exploration of duplicate states but records transitions
- Sequential state ID generation (S0, S1, S2, ...)
- Rule names derived automatically from class name
- Delegate-based TestRule for flexible inline test overrides
- 7 tests covering: basic build, initial state, starting state ID, cycle detection, transitions, and multi-state exploration

## Test plan
- [x] All 59 tests pass locally
- [x] Build succeeds with 0 warnings, 0 errors
- [ ] CI pipeline passes on this PR