### PR TITLE
Implement StateMachineBuilder with BFS/DFS, limits, and validation

### DIFF
--- a/src/StateMaker.Tests/StateMachineBuilderTests.cs
+++ b/src/StateMaker.Tests/StateMachineBuilderTests.cs
@@ -279,4 +279,153 @@ public class StateMachineBuilderTests
         var ex = Assert.Throws<ArgumentNullException>(() => builder.Build(initialState, rules, config));
         Assert.Equal("rules[1]", ex.ParamName);
     }
+
+    [Fact]
+    public void Build_LinearStateChain_TransitionsFormChain()
+    {
+        var builder = new StateMachineBuilder();
+        var initialState = new State();
+        initialState.Variables["step"] = 0;
+        var rules = new IRule[] { new TestRule(
+            _ => true,
+            s => { var c = s.Clone(); c.Variables["step"] = (int)c.Variables["step"]! + 1; return c; })
+        };
+        var config = new BuilderConfig { MaxStates = 4 };
+
+        StateMachine result = builder.Build(initialState, rules, config);
+
+        Assert.Equal(4, result.States.Count);
+        Assert.Equal(3, result.Transitions.Count);
+
+        var idByStep = result.States
+            .ToDictionary(kvp => (int)kvp.Value.Variables["step"]!, kvp => kvp.Key);
+
+        Assert.Contains(result.Transitions, t => t.SourceStateId == idByStep[0] && t.TargetStateId == idByStep[1]);
+        Assert.Contains(result.Transitions, t => t.SourceStateId == idByStep[1] && t.TargetStateId == idByStep[2]);
+        Assert.Contains(result.Transitions, t => t.SourceStateId == idByStep[2] && t.TargetStateId == idByStep[3]);
+    }
+
+    [Fact]
+    public void Build_BranchingStates_TwoBranchesFromInitial()
+    {
+        var builder = new StateMachineBuilder();
+        var initialState = new State();
+        initialState.Variables["branch"] = "start";
+        var rules = new IRule[]
+        {
+            new TestRule(
+                s => (string)s.Variables["branch"]! == "start",
+                s => { var c = s.Clone(); c.Variables["branch"] = "A"; return c; }),
+            new TestRule(
+                s => (string)s.Variables["branch"]! == "start",
+                s => { var c = s.Clone(); c.Variables["branch"] = "B"; return c; })
+        };
+        var config = new BuilderConfig();
+
+        StateMachine result = builder.Build(initialState, rules, config);
+
+        Assert.Equal(3, result.States.Count);
+        Assert.Equal(2, result.Transitions.Count);
+
+        var idByBranch = result.States
+            .ToDictionary(kvp => (string)kvp.Value.Variables["branch"]!, kvp => kvp.Key);
+
+        Assert.Contains(result.Transitions, t => t.SourceStateId == idByBranch["start"] && t.TargetStateId == idByBranch["A"]);
+        Assert.Contains(result.Transitions, t => t.SourceStateId == idByBranch["start"] && t.TargetStateId == idByBranch["B"]);
+    }
+
+    [Fact]
+    public void Build_CycleDetection_RecordsTransitionToExistingState()
+    {
+        var builder = new StateMachineBuilder();
+        var initialState = new State();
+        initialState.Variables["toggle"] = true;
+        var rules = new IRule[] { new TestRule(
+            _ => true,
+            s => { var c = s.Clone(); c.Variables["toggle"] = !(bool)c.Variables["toggle"]!; return c; })
+        };
+        var config = new BuilderConfig();
+
+        StateMachine result = builder.Build(initialState, rules, config);
+
+        Assert.Equal(2, result.States.Count);
+
+        var idByToggle = result.States
+            .ToDictionary(kvp => (bool)kvp.Value.Variables["toggle"]!, kvp => kvp.Key);
+
+        Assert.Equal(2, result.Transitions.Count);
+        Assert.Contains(result.Transitions, t => t.SourceStateId == idByToggle[true] && t.TargetStateId == idByToggle[false]);
+        Assert.Contains(result.Transitions, t => t.SourceStateId == idByToggle[false] && t.TargetStateId == idByToggle[true]);
+    }
+
+    [Fact]
+    public void Build_EmptyRulesArray_ReturnsSingleStateNoTransitions()
+    {
+        var builder = new StateMachineBuilder();
+        var initialState = new State();
+        initialState.Variables["status"] = "alone";
+        var rules = Array.Empty<IRule>();
+        var config = new BuilderConfig();
+
+        StateMachine result = builder.Build(initialState, rules, config);
+
+        Assert.Single(result.States);
+        Assert.Empty(result.Transitions);
+        Assert.Equal("alone", result.States[result.StartingStateId!].Variables["status"]);
+    }
+
+    [Fact]
+    public void Build_AllRulesAlwaysAvailable_AllAppliedToEachState()
+    {
+        var builder = new StateMachineBuilder();
+        var initialState = new State();
+        initialState.Variables["x"] = 0;
+        initialState.Variables["y"] = 0;
+        var rules = new IRule[]
+        {
+            new TestRule(
+                _ => true,
+                s => { var c = s.Clone(); c.Variables["x"] = (int)c.Variables["x"]! + 1; return c; }),
+            new TestRule(
+                _ => true,
+                s => { var c = s.Clone(); c.Variables["y"] = (int)c.Variables["y"]! + 1; return c; })
+        };
+        var config = new BuilderConfig { MaxStates = 5 };
+
+        StateMachine result = builder.Build(initialState, rules, config);
+
+        Assert.Equal(5, result.States.Count);
+        Assert.Contains(result.States.Values, s => (int)s.Variables["x"]! == 1 && (int)s.Variables["y"]! == 0);
+        Assert.Contains(result.States.Values, s => (int)s.Variables["x"]! == 0 && (int)s.Variables["y"]! == 1);
+    }
+
+    [Fact]
+    public void Build_TwoRulesProduceSameState_NoDuplicateAndBothTransitionsRecorded()
+    {
+        var builder = new StateMachineBuilder();
+        var initialState = new State();
+        initialState.Variables["value"] = 0;
+        var rules = new IRule[]
+        {
+            new TestRule(
+                s => (int)s.Variables["value"]! == 0,
+                s => { var c = s.Clone(); c.Variables["value"] = 1; return c; }),
+            new TestRule(
+                s => (int)s.Variables["value"]! == 0,
+                s => { var c = s.Clone(); c.Variables["value"] = 1; return c; })
+        };
+        var config = new BuilderConfig();
+
+        StateMachine result = builder.Build(initialState, rules, config);
+
+        Assert.Equal(2, result.States.Count);
+
+        var targetId = result.States.First(kvp => kvp.Key != result.StartingStateId).Key;
+        Assert.Equal(2, result.Transitions.Count);
+        Assert.All(result.Transitions, t =>
+        {
+            Assert.Equal(result.StartingStateId, t.SourceStateId);
+            Assert.Equal(targetId, t.TargetStateId);
+        });
+    }
 }

--- a/tasks/tasks-state-machine-builder.md
+++ b/tasks/tasks-state-machine-builder.md
@@ -84,9 +84,9 @@ All tests must pass before moving on to the next sub-task.
   - [x] 3.2 Implement `StateMachineBuilder` class with BFS exploration: use a queue of states, apply all available rules to each state
   - [x] 3.3 Implement cycle detection using `HashSet<State>` — skip exploration when an equivalent state already exists, but still record the transition
   - [x] 3.4 Implement sequential state ID generation (S0, S1, S2, ...)
-  - [ ] 3.5 Implement `MaxDepth` limit: track depth per state and stop exploring paths beyond the configured depth
-  - [ ] 3.6 Implement `MaxStates` limit: stop adding new states once the limit is reached
-  - [ ] 3.7 Implement DFS exploration strategy as an alternative to BFS (selected via `BuilderConfig.ExplorationStrategy`)
+  - [x] 3.5 Implement `MaxDepth` limit: track depth per state and stop exploring paths beyond the configured depth
+  - [x] 3.6 Implement `MaxStates` limit: stop adding new states once the limit is reached
+  - [x] 3.7 Implement DFS exploration strategy as an alternative to BFS (selected via `BuilderConfig.ExplorationStrategy`)
   - [x] 3.8 Derive rule names automatically from the rule class name (or allow configurable names)
   - [ ] 3.9 Write unit tests: simple linear state chain, branching states, cycle detection, depth limit respected, state count limit respected, BFS vs DFS ordering
   - [ ] 3.10 Write unit tests: no rules available (returns single-state machine), all rules always available, rules that produce duplicate states

--- a/tasks/tasks-state-machine-builder.md
+++ b/tasks/tasks-state-machine-builder.md
@@ -79,7 +79,7 @@ All tests must pass before moving on to the next sub-task.
   - [x] 2.10 Implement `BuilderConfig` class with `MaxDepth` (int?), `MaxStates` (int?), `ExplorationStrategy` (enum: BFS, DFS), and `LogLevel` (enum: INFO, DEBUG, ERROR)
   - [x] 2.11 Write unit tests for BuilderConfig default values and Transition properties
 
-- [ ] 3.0 Implement StateMachineBuilder with BFS/DFS exploration and cycle detection
+- [x] 3.0 Implement StateMachineBuilder with BFS/DFS exploration and cycle detection
   - [x] 3.1 Define `IStateMachineBuilder` interface with `StateMachine Build(State initialState, IRule[] rules, BuilderConfig config)` method
   - [x] 3.2 Implement `StateMachineBuilder` class with BFS exploration: use a queue of states, apply all available rules to each state
   - [x] 3.3 Implement cycle detection using `HashSet<State>` — skip exploration when an equivalent state already exists, but still record the transition
@@ -88,8 +88,8 @@ All tests must pass before moving on to the next sub-task.
   - [x] 3.6 Implement `MaxStates` limit: stop adding new states once the limit is reached
   - [x] 3.7 Implement DFS exploration strategy as an alternative to BFS (selected via `BuilderConfig.ExplorationStrategy`)
   - [x] 3.8 Derive rule names automatically from the rule class name (or allow configurable names)
-  - [ ] 3.9 Write unit tests: simple linear state chain, branching states, cycle detection, depth limit respected, state count limit respected, BFS vs DFS ordering
-  - [ ] 3.10 Write unit tests: no rules available (returns single-state machine), all rules always available, rules that produce duplicate states
+  - [x] 3.9 Write unit tests: simple linear state chain, branching states, cycle detection, depth limit respected, state count limit respected, BFS vs DFS ordering
+  - [x] 3.10 Write unit tests: no rules available (returns single-state machine), all rules always available, rules that produce duplicate states
 
 - [ ] 4.0 Implement configuration validation
   - [ ] 4.1 Add null check for initial state — throw `ArgumentNullException` with message "No initial state provided"


### PR DESCRIPTION
## Summary
- Implement StateMachineBuilder with BFS and DFS exploration strategies using a unified LinkedList frontier
- Add MaxDepth and MaxStates limits to control state space exploration
- Add cycle detection via HashSet with transition recording for revisited states
- Add ArgumentNullException guards for all Build parameters, including null elements in the rules array
- Sequential state ID generation (S0, S1, S2, ...)

## Test plan
- [x] Basic build returns a StateMachine
- [x] Initial state is present in result with correct variables
- [x] StartingStateId is set and references a valid state
- [x] Clone-only rules produce a single state (cycle detection)
- [x] Unavailable rules produce zero transitions
- [x] Available rules produce transitions
- [x] Rules producing new state values create additional states
- [x] MaxDepth stops exploration at configured depth
- [x] MaxStates stops adding states at configured limit
- [x] DFS explores depth-first order
- [x] BFS explores breadth-first order
- [x] Null initialState throws ArgumentNullException
- [x] Null rules array throws ArgumentNullException
- [x] Null config throws ArgumentNullException
- [x] Null rule element in array throws ArgumentNullException