### PR TITLE
Add IsValidMachine and builder test coverage

### DIFF
--- a/src/StateMaker.Tests/StateMachineTests.cs
+++ b/src/StateMaker.Tests/StateMachineTests.cs
@@ -126,4 +126,80 @@ public class StateMachineTests
 
         Assert.IsAssignableFrom<IReadOnlyDictionary<string, State>>(machine.States);
     }
+
+    [Fact]
+    public void IsValidMachine_SingleStateWithStartingStateId_ReturnsTrue()
+    {
+        var machine = new StateMachine();
+        machine.AddState("S0", new State());
+        machine.StartingStateId = "S0";
+
+        Assert.True(machine.IsValidMachine());
+    }
+
+    [Fact]
+    public void IsValidMachine_TwoStatesWithTransition_ReturnsTrue()
+    {
+        var machine = new StateMachine();
+        machine.AddState("S0", new State());
+        machine.AddState("S1", new State());
+        machine.StartingStateId = "S0";
+        machine.Transitions.Add(new Transition("S0", "S1", "Rule1"));
+
+        Assert.True(machine.IsValidMachine());
+    }
+
+    [Fact]
+    public void IsValidMachine_CycleTransitions_ReturnsTrue()
+    {
+        var machine = new StateMachine();
+        machine.AddState("S0", new State());
+        machine.AddState("S1", new State());
+        machine.StartingStateId = "S0";
+        machine.Transitions.Add(new Transition("S0", "S1", "Rule1"));
+        machine.Transitions.Add(new Transition("S1", "S0", "Rule1"));
+
+        Assert.True(machine.IsValidMachine());
+    }
+
+    [Fact]
+    public void IsValidMachine_NoStates_ReturnsFalse()
+    {
+        var machine = new StateMachine();
+
+        Assert.False(machine.IsValidMachine());
+    }
+
+    [Fact]
+    public void IsValidMachine_NullStartingStateId_ReturnsFalse()
+    {
+        var machine = new StateMachine();
+        machine.AddState("S0", new State());
+
+        Assert.False(machine.IsValidMachine());
+    }
+
+    [Fact]
+    public void IsValidMachine_TransitionSourceStateDoesNotExist_ReturnsFalse()
+    {
+        var machine = new StateMachine();
+        machine.AddState("S0", new State());
+        machine.AddState("S1", new State());
+        machine.StartingStateId = "S0";
+        machine.Transitions.Add(new Transition("S99", "S1", "Rule1"));
+
+        Assert.False(machine.IsValidMachine());
+    }
+
+    [Fact]
+    public void IsValidMachine_TransitionTargetStateDoesNotExist_ReturnsFalse()
+    {
+        var machine = new StateMachine();
+        machine.AddState("S0", new State());
+        machine.AddState("S1", new State());
+        machine.StartingStateId = "S0";
+        machine.Transitions.Add(new Transition("S0", "S99", "Rule1"));
+
+        Assert.False(machine.IsValidMachine());
+    }
 }

--- a/src/StateMaker/StateMachine.cs
+++ b/src/StateMaker/StateMachine.cs
@@ -27,6 +27,24 @@ public class StateMachine
         _states[stateId] = state;
     }
 
+    public bool IsValidMachine()
+    {
+        if (_states.Count == 0)
+            return false;
+
+        if (_startingStateId is null)
+            return false;
+
+        foreach (var transition in Transitions)
+        {
+            if (!_states.ContainsKey(transition.SourceStateId) ||
+                !_states.ContainsKey(transition.TargetStateId))
+                return false;
+        }
+
+        return true;
+    }
+
     public bool RemoveState(string stateId)
     {
         var removed = _states.Remove(stateId);


### PR DESCRIPTION
## Summary
- Add IsValidMachine() to StateMachine that validates non-empty states, non-null StartingStateId, and all transition references point to existing states
- Add IsValidMachine assertion to all 16 StateMachineBuilder tests that produce a successful Build result
- Add 7 unit tests for IsValidMachine covering valid and invalid conditions
- Add Build_RuleThatBuildsUntilValueEqualsCertainAmount test
- Complete tasks 3.9 and 3.10 with tests for linear chains, branching, cycle detection, empty rules, all-available rules, and duplicate state production

## Test plan
- [x] IsValidMachine returns true for single state with StartingStateId
- [x] IsValidMachine returns true for two states with valid transition
- [x] IsValidMachine returns true for cycle transitions
- [x] IsValidMachine returns false for no states
- [x] IsValidMachine returns false for null StartingStateId
- [x] IsValidMachine returns false for invalid transition source
- [x] IsValidMachine returns false for invalid transition target
- [x] All builder tests assert IsValidMachine on result