### PR TITLE
Add IRule.GetName() to interface and update docs

### DIFF
--- a/docs/architecture/builder-architecture.md
+++ b/docs/architecture/builder-architecture.md
@@ -57,13 +57,13 @@ Explore:
 
         if visited contains equivalent state:
           // Cycle detected - create transition to existing state
-          add Transition(currentState → existingState, rule.Name)
+          add Transition(currentState → existingState, rule.GetName())
         else:
           // New state discovered
           assign unique ID to newState
           add newState to StateMachine
           add newState to visited set
-          add Transition(currentState → newState, rule.Name)
+          add Transition(currentState → newState, rule.GetName())
 
           if limits not reached:
             add newState to exploration queue

--- a/docs/architecture/declarative-rules.md
+++ b/docs/architecture/declarative-rules.md
@@ -21,11 +21,12 @@ namespace StateMaker
     {
         bool IsAvailable(State state);
         State Execute(State state);
+        string GetName();  // Default returns GetType().Name; override for custom name
     }
 }
 ```
 
-This simple two-method interface is the foundation for both custom and declarative rules.
+This three-method interface is the foundation for both custom and declarative rules. The `GetName()` method provides the rule name used in transitions; by default it returns the type name, but implementers can override it.
 
 ### 2. Custom Code-Based Rules
 
@@ -51,6 +52,12 @@ public class AddOptionRule : IRule
         var optionList = newState.Variables["OptionList"] as List<string>;
         optionList.Add("NewOption");
         return newState;
+    }
+
+    public string GetName()
+    {
+        // Default: return type name. Override for a custom name.
+        return GetType().Name;
     }
 }
 ```
@@ -106,6 +113,12 @@ namespace StateMaker
             }
 
             return newState;
+        }
+
+        public string GetName()
+        {
+            // Returns the declarative rule's configured name
+            return _name;
         }
     }
 }
@@ -268,7 +281,7 @@ var stateMachine = builder.Build(initialState, allRules, config);
 ## Design Principles
 
 ### 1. Interface Segregation
-- `IRule` contains only two essential methods
+- `IRule` contains only three essential methods (`IsAvailable`, `Execute`, `GetName`)
 - Simple contract makes both custom and declarative implementations straightforward
 
 ### 2. Polymorphism

--- a/tasks/prd-state-machine-builder.md
+++ b/tasks/prd-state-machine-builder.md
@@ -136,6 +136,7 @@ Scenario: Implement a custom rule class
   And I implement the IsAvailable(State state) method to check if the rule applies
   And I implement the Execute(State state) method to return the new state
   Then I have a custom rule class ready to use
+  And I implement the GetName() method to return the name of the rule if I want it to be different than the default matching the type name of the rule object.
 
 Scenario: Developer implements custom rule AddOption.IsAvailable so that the rule will fire when "OptionList <> Empty"
   Given I am implementing the AddOption rule class
@@ -275,9 +276,10 @@ Scenario: Developer loads business analyst's definition file and builds state ma
 1. The system must provide a `State` class that stores a set of variables with their values
 2. The `State` class must allow programmatic construction by providing variable names and their values
 3. The `State` class must implement equality comparison to determine if two states are equivalent (same variables with same values)
-4. The system must provide a `Rule` interface with two methods:
+4. The system must provide a `Rule` interface with three methods:
    - `bool IsAvailable(State state)` - returns true if the rule can be applied to the given state
    - `State Execute(State state)` - returns a new state resulting from applying the rule
+   - `string GetName()` - returns the name of the rule; the default implementation returns the type name of the rule object, but implementers can override this to provide a custom name
 5. The system must provide a `StateMachine` class with the following properties and methods:
    - `IReadOnlyDictionary<string, State> States` - all discovered states, keyed by unique ID (read-only; mutations via `AddState`/`RemoveState` methods)
    - `void AddState(string stateId, State state)` - adds a state to the state machine
@@ -329,7 +331,7 @@ Scenario: Developer loads business analyst's definition file and builds state ma
 
 32. All interfaces (`IRule`, `IStateMachineBuilder`) and core classes (`State`, `StateMachine`, `BuilderConfig`, `Transition`) must be in the `StateMaker` namespace
 33. The namespace must be designed to allow external assemblies to reference it and implement custom `IRule` implementations
-34. Rule names should be automatically derived from the rule class name (or configurable)
+34. Rule names must be obtained by calling `IRule.GetName()`; the default implementation returns the rule's type name, and implementers may override it to provide a custom name
 
 ### Declarative Rule Definition
 

--- a/tasks/tasks-state-machine-builder.md
+++ b/tasks/tasks-state-machine-builder.md
@@ -90,20 +90,21 @@ All tests must pass before moving on to the next sub-task.
   - [x] 3.8 Derive rule names automatically from the rule class name (or allow configurable names)
   - [x] 3.9 Write unit tests: simple linear state chain, branching states, cycle detection, depth limit respected, state count limit respected, BFS vs DFS ordering
   - [x] 3.10 Write unit tests: no rules available (returns single-state machine), all rules always available, rules that produce duplicate states
-  - [ ] 3.11 Write tests with rules designed to produce specific state machine shapes: single state (no transitions fire), chains of varying length, and simple cycles
-  - [ ] 3.12 Write tests with rules designed to produce complex cycle shapes: cycles of varying depth and start points, cycles within cycles, and cycles with optional exits
-  - [ ] 3.13 Write tests with rules designed to produce branching shapes: varying peer count, depth, breadth, sub-branches as trees, connected sub-branches, and fully connected branches
-  - [ ] 3.14 Write tests with rules designed to produce reconnecting branches (diamond/converging paths) and fully connected graphs with varying node counts
-  - [ ] 3.15 Write tests with rules designed to produce hybrid shapes combining multiple topologies (chains + cycles, branches + cycles, multiple shape neighborhoods)
-  - [ ] 3.16 Write tests verifying exploration strategy equivalence: same initial state, rules, and config must produce the same state machine (same states and transitions) under both BFS and DFS
-  - [ ] 3.17 Write tests for rule behavior edge cases: rules that always generate unique states (unbounded growth), rules that return malformed or unexpected states
-  - [ ] 3.18 Write tests for rule behavior edge cases: rules whose `IsAvailable` or `Execute` methods throw exceptions, and rules whose methods hang or take excessively long
-  - [ ] 3.19 Write tests for rule behavior edge cases: rules that mutate the input state passed to `Execute` (violating immutability), verifying the builder handles or detects this
-  - [ ] 3.20 Write tests for resilience: null rules array, null elements within rules array, null config, and building from configurations with contradictory or nonsensical limits (e.g., MaxStates=0, MaxDepth=-1)
-  - [ ] 3.21 Implement a test case generator tool that programmatically combines initial state shapes (no variables, one of each data type, multiple variables, 1..N), config combinations (MaxStates x MaxDepth pairwise from null/0/-1/1/2/3/10), and rule variations (sets variable, adds variable, increments, empty) to produce build definition files
-  - [ ] 3.22 Implement a test battery executor tool that runs a set of build definitions through the builder and applies oracle checks: no crash/exception, no infinite loop (heuristic timeout), MaxStates and MaxDepth limits respected in output
-  - [ ] 3.23 Implement oracle checks in the test battery executor for performance validation: time-to-size ratio within expected bounds, and expected state machine shape matching for tractable cases
-  - [ ] 3.24 Implement a reverse rule generator tool that takes a target state machine shape as input and generates one or more sets of rules that would build it, including variations (extra non-triggering rules, different rule orderings) that should not alter the expected output
+  - [ ] 3.11 Add `string GetName()` method to `IRule` interface (default returns `GetType().Name`), update `StateMachineBuilder` to call `rule.GetName()` instead of `rule.GetType().Name` when assigning `Transition.RuleName`, update `DeclarativeRule` to return its configured name from `GetName()`, and write unit tests verifying default and custom name behavior for both custom and declarative rules
+  - [ ] 3.12 Write tests with rules designed to produce specific state machine shapes: single state (no transitions fire), chains of varying length, and simple cycles
+  - [ ] 3.13 Write tests with rules designed to produce complex cycle shapes: cycles of varying depth and start points, cycles within cycles, and cycles with optional exits
+  - [ ] 3.14 Write tests with rules designed to produce branching shapes: varying peer count, depth, breadth, sub-branches as trees, connected sub-branches, and fully connected branches
+  - [ ] 3.15 Write tests with rules designed to produce reconnecting branches (diamond/converging paths) and fully connected graphs with varying node counts
+  - [ ] 3.16 Write tests with rules designed to produce hybrid shapes combining multiple topologies (chains + cycles, branches + cycles, multiple shape neighborhoods)
+  - [ ] 3.17 Write tests verifying exploration strategy equivalence: same initial state, rules, and config must produce the same state machine (same states and transitions) under both BFS and DFS
+  - [ ] 3.18 Write tests for rule behavior edge cases: rules that always generate unique states (unbounded growth), rules that return malformed or unexpected states
+  - [ ] 3.19 Write tests for rule behavior edge cases: rules whose `IsAvailable` or `Execute` methods throw exceptions, and rules whose methods hang or take excessively long
+  - [ ] 3.20 Write tests for rule behavior edge cases: rules that mutate the input state passed to `Execute` (violating immutability), verifying the builder handles or detects this
+  - [ ] 3.21 Write tests for resilience: null rules array, null elements within rules array, null config, and building from configurations with contradictory or nonsensical limits (e.g., MaxStates=0, MaxDepth=-1)
+  - [ ] 3.22 Implement a test case generator tool that programmatically combines initial state shapes (no variables, one of each data type, multiple variables, 1..N), config combinations (MaxStates x MaxDepth pairwise from null/0/-1/1/2/3/10), and rule variations (sets variable, adds variable, increments, empty) to produce build definition files
+  - [ ] 3.23 Implement a test battery executor tool that runs a set of build definitions through the builder and applies oracle checks: no crash/exception, no infinite loop (heuristic timeout), MaxStates and MaxDepth limits respected in output
+  - [ ] 3.24 Implement oracle checks in the test battery executor for performance validation: time-to-size ratio within expected bounds, and expected state machine shape matching for tractable cases
+  - [ ] 3.25 Implement a reverse rule generator tool that takes a target state machine shape as input and generates one or more sets of rules that would build it, including variations (extra non-triggering rules, different rule orderings) that should not alter the expected output
 
 - [ ] 4.0 Implement configuration validation
   - [ ] 4.1 Add null check for initial state — throw `ArgumentNullException` with message "No initial state provided"


### PR DESCRIPTION
## Summary
- Added  method to  interface definition in PRD (FR 4) and updated rule name derivation requirement (FR 34)
- Updated builder-architecture.md exploration pseudocode to call 
- Updated declarative-rules.md with  in IRule definition, custom rule example, and DeclarativeRule implementation
- Inserted new task 3.11 for implementing GetName() and renumbered existing 3.11-3.24 to 3.12-3.25

## Test plan
- [ ] Verify PRD accurately describes GetName() behavior and default implementation
- [ ] Verify architecture docs are consistent with the new interface method
- [ ] Verify task 3.11 covers IRule, StateMachineBuilder, DeclarativeRule, and tests
- [ ] Verify renumbered tasks 3.12-3.25 are intact and correctly sequenced