### PR TITLE
Add hybrid shape tests combining multiple topologies (task 3.16)

### DIFF
--- a/tasks/prd-hybrid-shape-tests.md
+++ b/tasks/prd-hybrid-shape-tests.md
@@ -1,0 +1,45 @@
+# PRD: Hybrid Shape Tests (Task 3.16)
+
+## Objective
+Write tests with rules designed to produce hybrid shapes combining multiple topologies (chains + cycles, branches + cycles, multiple shape neighborhoods).
+
+## Background
+Tasks 3.12-3.15 verified individual shape categories (chains, cycles, complex cycles, branches, reconnecting branches, fully connected graphs). Task 3.16 combines these topologies to verify the builder correctly handles graphs that contain multiple distinct shape regions in a single state machine.
+
+## Test Categories
+
+### 1. Chain + Cycle Hybrids
+Tests where a chain leads into a cycle, or a chain branches into both a terminal path and a cycle.
+- Chain prefix followed by a cycle (already covered in 3.13 as chain-then-cycle, but here we combine with other shapes)
+- Chain that branches: one branch terminates, other enters a cycle
+- Two independent chain-then-cycle segments reachable from a common root
+
+### 2. Branch + Cycle Hybrids
+Tests where branching structures contain cycles in one or more branches.
+- Root branches to a terminal chain and a cycle
+- Root branches to two independent cycles of different lengths
+- Tree structure where leaf nodes enter cycles
+- Diamond shape where convergence point enters a cycle
+
+### 3. Multiple Shape Neighborhoods
+Tests where the graph contains distinct topological regions connected by transitions.
+- Chain -> branch -> cycle (three-phase topology)
+- Diamond with one branch containing a cycle and other branch being a chain
+- Fully connected sub-graph reachable from a chain prefix
+- Two diamonds connected by a chain, with a cycle at the end
+
+### 4. Complex Hybrid Compositions
+Tests combining three or more distinct topologies.
+- Branch where each arm has a different topology (chain, cycle, diamond)
+- Chain -> diamond -> cycle -> terminal
+- Nested structure: outer cycle with inner branch containing a sub-cycle
+
+## Assertions
+- Correct total state and transition counts
+- All states reachable from start
+- `IsValidMachine()` returns true
+- Specific structural properties (e.g., cycle detection, convergence points, terminal states)
+
+## Files Modified
+- `src/StateMaker.Tests/StateMachineShapeTests.cs` — new test region and test methods
+- `tasks/tasks-state-machine-builder.md` — sub-tasks and completion tracking

--- a/tasks/tasks-state-machine-builder.md
+++ b/tasks/tasks-state-machine-builder.md
@@ -128,7 +128,12 @@ All tests must pass before moving on to the next sub-task.
     - [x] 3.15.6 Write nested diamond tests: one branch is a sub-diamond converging at the outer convergence point, both branches contain sub-diamonds converging at the same final state
     - [x] 3.15.7 Write parameterized fully connected graph tests using `[Theory]` with node counts (2, 3, 4, 5): verify K states, K*(K-1) transitions, every state has outDegree == inDegree == K-1
     - [x] 3.15.8 Verify all new reconnecting branch and fully connected graph tests pass alongside existing 150+ tests, ensure at least 3 distinct variations per category
-  - [ ] 3.16 Write tests with rules designed to produce hybrid shapes combining multiple topologies (chains + cycles, branches + cycles, multiple shape neighborhoods)
+  - [x] 3.16 Write tests with rules designed to produce hybrid shapes combining multiple topologies (chains + cycles, branches + cycles, multiple shape neighborhoods)
+    - [x] 3.16.1 Write chain + cycle hybrid tests: chain that branches to a terminal path and a cycle, two independent chain-then-cycle segments from a common root
+    - [x] 3.16.2 Write branch + cycle hybrid tests: root branches to a terminal chain and a cycle, root branches to two independent cycles of different lengths, diamond convergence point entering a cycle
+    - [x] 3.16.3 Write multiple shape neighborhood tests: chain -> branch -> cycle (three-phase topology), diamond with one cyclic branch and one chain branch, fully connected sub-graph reachable from a chain prefix
+    - [x] 3.16.4 Write complex hybrid composition tests: branch where each arm has a different topology (chain, cycle, diamond), chain -> diamond -> cycle -> terminal, nested outer cycle with inner branch containing a sub-cycle
+    - [x] 3.16.5 Verify all new hybrid shape tests pass alongside existing 167+ tests, ensure at least 3 distinct variations per hybrid category
   - [ ] 3.17 Write tests verifying exploration strategy equivalence: same initial state, rules, and config must produce the same state machine (same states and transitions) under both BFS and DFS
   - [ ] 3.18 Write tests for rule behavior edge cases: rules that always generate unique states (unbounded growth), rules that return malformed or unexpected states
   - [ ] 3.19 Write tests for rule behavior edge cases: rules whose `IsAvailable` or `Execute` methods throw exceptions, and rules whose methods hang or take excessively long


### PR DESCRIPTION
## Summary
- Adds 15 hybrid shape tests that combine multiple topologies: chains + cycles, branches + cycles, multiple shape neighborhoods, and complex compositions
- Covers chain-to-cycle, branch-to-cycle, diamond-to-cycle, tree-with-cycle-leaves, three-phase topologies, fully connected subgraphs from chains, stacked diamonds with cycles, and branches with mixed topology arms
- Total test count: 182 (167 existing + 15 new)

## Test plan
- [x] All 182 tests pass locally with `dotnet test`
- [ ] CI build passes (no CA1305 or other analyzer warnings)

Generated with [Claude Code](https://claude.com/claude-code)