### PR TITLE
Add exploration strategy equivalence tests for BFS vs DFS (task 3.17)

### DIFF
--- a/tasks/prd-exploration-strategy-equivalence-tests.md
+++ b/tasks/prd-exploration-strategy-equivalence-tests.md
@@ -1,0 +1,47 @@
+# PRD: Exploration Strategy Equivalence Tests (Task 3.17)
+
+## Objective
+Write tests verifying exploration strategy equivalence: same initial state, rules, and config must produce the same state machine (same states and transitions) under both BFS and DFS.
+
+## Background
+The `StateMachineBuilder` supports two exploration strategies: `BREADTHFIRSTSEARCH` and `DEPTHFIRSTSEARCH`. While the traversal order differs (affecting state ID assignment), both strategies should discover the same set of states (by variable values) and the same set of transitions (by source/target state variables and rule name). This task verifies that structural equivalence holds across all previously tested shape categories.
+
+## Key Insight
+State IDs (S0, S1, S2...) are assigned sequentially as states are discovered, so BFS and DFS will produce different ID assignments. Equivalence must be checked structurally:
+- Same number of states
+- Same set of state variable dictionaries
+- Same number of transitions
+- Same set of transitions when mapped through state variables (not IDs)
+
+## Test Categories
+
+### 1. Simple Shape Equivalence
+- Single state (trivially equivalent)
+- Chain shapes of varying lengths
+- Simple cycle shapes
+
+### 2. Branching Shape Equivalence
+- Binary tree structures
+- Fan-out branches
+- Connected sub-branches (deduplication)
+
+### 3. Complex Shape Equivalence
+- Chain-then-cycle
+- Diamonds (reconverging branches)
+- Nested cycles
+
+### 4. Hybrid Shape Equivalence
+- Branch + cycle hybrids
+- Multi-topology compositions
+- Fully connected subgraphs
+
+## Assertions
+- `AssertStrategyEquivalence` helper: builds with BFS and DFS, then compares:
+  - Equal state counts
+  - Same set of state variable dictionaries
+  - Equal transition counts
+  - Same set of (sourceVars, targetVars, ruleName) transition triples
+
+## Files Modified
+- `src/StateMaker.Tests/StateMachineShapeTests.cs` — new test region and helper
+- `tasks/tasks-state-machine-builder.md` — sub-tasks and completion tracking

--- a/tasks/tasks-state-machine-builder.md
+++ b/tasks/tasks-state-machine-builder.md
@@ -134,7 +134,13 @@ All tests must pass before moving on to the next sub-task.
     - [x] 3.16.3 Write multiple shape neighborhood tests: chain -> branch -> cycle (three-phase topology), diamond with one cyclic branch and one chain branch, fully connected sub-graph reachable from a chain prefix
     - [x] 3.16.4 Write complex hybrid composition tests: branch where each arm has a different topology (chain, cycle, diamond), chain -> diamond -> cycle -> terminal, nested outer cycle with inner branch containing a sub-cycle
     - [x] 3.16.5 Verify all new hybrid shape tests pass alongside existing 167+ tests, ensure at least 3 distinct variations per hybrid category
-  - [ ] 3.17 Write tests verifying exploration strategy equivalence: same initial state, rules, and config must produce the same state machine (same states and transitions) under both BFS and DFS
+  - [x] 3.17 Write tests verifying exploration strategy equivalence: same initial state, rules, and config must produce the same state machine (same states and transitions) under both BFS and DFS
+    - [x] 3.17.1 Implement `AssertStrategyEquivalence` helper method that builds with both BFS and DFS configs and compares structural equivalence: same state count, same set of state variable dictionaries, same transition count, same set of (sourceVars, targetVars, ruleName) triples
+    - [x] 3.17.2 Write simple shape equivalence tests: single state (no rules), chain of length 5, cycle of length 4, self-loop
+    - [x] 3.17.3 Write branching shape equivalence tests: binary tree depth 2, fan-out of 4, connected sub-branches with deduplication
+    - [x] 3.17.4 Write complex shape equivalence tests: chain-then-cycle (3,3), diamond (2-branch), nested cycles (outer 3 inner 2), cycle with exit chain
+    - [x] 3.17.5 Write hybrid shape equivalence tests: branch to chain and cycle, diamond then cycle, three-phase chain-branch-cycle, branch with mixed topology arms
+    - [x] 3.17.6 Verify all new equivalence tests pass alongside existing 182+ tests
   - [ ] 3.18 Write tests for rule behavior edge cases: rules that always generate unique states (unbounded growth), rules that return malformed or unexpected states
   - [ ] 3.19 Write tests for rule behavior edge cases: rules whose `IsAvailable` or `Execute` methods throw exceptions, and rules whose methods hang or take excessively long
   - [ ] 3.20 Write tests for rule behavior edge cases: rules that mutate the input state passed to `Execute` (violating immutability), verifying the builder handles or detects this


### PR DESCRIPTION
## Summary
- Adds 15 tests verifying that BFS and DFS exploration strategies produce structurally equivalent state machines
- Implements `AssertStrategyEquivalence` helper that compares state variable sets and (sourceVars, targetVars, ruleName) transition triples between BFS and DFS builds
- Covers simple shapes (single state, chain, cycle, self-loop), branching (binary tree, fan-out, deduplication), complex (chain-then-cycle, diamond, nested cycles), and hybrid topologies
- Total test count: 197 (182 existing + 15 new)

## Test plan
- [x] All 197 tests pass locally with `dotnet test`
- [ ] CI build passes

Generated with [Claude Code](https://claude.com/claude-code)