### PR TITLE
Add test case generator and battery executor (tasks 3.22, 3.23)

### DIFF
--- a/src/StateMaker.Tests/TestBatteryExecutor.cs
+++ b/src/StateMaker.Tests/TestBatteryExecutor.cs
@@ -1,0 +1,136 @@
+using System.Globalization;
+
+namespace StateMaker.Tests;
+
+public record TestBatteryResult(
+    string DefinitionName,
+    bool Passed,
+    string? FailureReason,
+    int StateCount,
+    int TransitionCount);
+
+public static class TestBatteryExecutor
+{
+    private static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(5);
+
+    public static TestBatteryResult Run(BuildDefinition definition)
+    {
+        return Run(definition, DefaultTimeout);
+    }
+
+    public static TestBatteryResult Run(BuildDefinition definition, TimeSpan timeout)
+    {
+        var builder = new StateMachineBuilder();
+        StateMachine? result = null;
+
+        // Oracle 1 & 2: No crash/exception and no infinite loop (timeout)
+        try
+        {
+            var task = Task.Run(() => builder.Build(definition.InitialState, definition.Rules, definition.Config));
+            if (!task.Wait(timeout))
+            {
+                return new TestBatteryResult(definition.Name, false, "Timeout: Build did not complete within " + timeout.TotalSeconds.ToString(CultureInfo.InvariantCulture) + "s", 0, 0);
+            }
+            result = task.Result;
+        }
+        catch (AggregateException ex)
+        {
+            return new TestBatteryResult(definition.Name, false, $"Exception: {ex.InnerException?.Message ?? ex.Message}", 0, 0);
+        }
+        catch (Exception ex)
+        {
+            return new TestBatteryResult(definition.Name, false, $"Exception: {ex.Message}", 0, 0);
+        }
+
+        int stateCount = result.States.Count;
+        int transitionCount = result.Transitions.Count;
+
+        // Oracle 3: MaxStates respected
+        if (definition.Config.MaxStates.HasValue && definition.Config.MaxStates.Value > 0)
+        {
+            if (stateCount > definition.Config.MaxStates.Value)
+            {
+                return new TestBatteryResult(definition.Name, false,
+                    $"MaxStates violated: {stateCount.ToString(CultureInfo.InvariantCulture)} states exceeds limit of {definition.Config.MaxStates.Value.ToString(CultureInfo.InvariantCulture)}",
+                    stateCount, transitionCount);
+            }
+        }
+
+        // Oracle 4: MaxDepth respected (BFS path-length from start)
+        if (definition.Config.MaxDepth.HasValue && definition.Config.MaxDepth.Value > 0 && result.StartingStateId is not null)
+        {
+            int? maxObservedDepth = ComputeMaxDepth(result);
+            if (maxObservedDepth.HasValue && maxObservedDepth.Value > definition.Config.MaxDepth.Value)
+            {
+                return new TestBatteryResult(definition.Name, false,
+                    $"MaxDepth violated: observed depth {maxObservedDepth.Value.ToString(CultureInfo.InvariantCulture)} exceeds limit of {definition.Config.MaxDepth.Value.ToString(CultureInfo.InvariantCulture)}",
+                    stateCount, transitionCount);
+            }
+        }
+
+        // Oracle 5: Valid machine
+        if (!result.IsValidMachine())
+        {
+            return new TestBatteryResult(definition.Name, false, "IsValidMachine() returned false", stateCount, transitionCount);
+        }
+
+        return new TestBatteryResult(definition.Name, true, null, stateCount, transitionCount);
+    }
+
+    public static IEnumerable<TestBatteryResult> RunAll(IEnumerable<BuildDefinition> definitions)
+    {
+        return RunAll(definitions, DefaultTimeout);
+    }
+
+    public static IEnumerable<TestBatteryResult> RunAll(IEnumerable<BuildDefinition> definitions, TimeSpan timeout)
+    {
+        foreach (var definition in definitions)
+        {
+            yield return Run(definition, timeout);
+        }
+    }
+
+    private static int? ComputeMaxDepth(StateMachine machine)
+    {
+        if (machine.StartingStateId is null || machine.States.Count == 0)
+            return null;
+
+        // Build adjacency list from transitions
+        var adjacency = new Dictionary<string, List<string>>();
+        foreach (var state in machine.States)
+        {
+            adjacency[state.Key] = new List<string>();
+        }
+        foreach (var transition in machine.Transitions)
+        {
+            if (adjacency.TryGetValue(transition.SourceStateId, out var neighbors))
+            {
+                neighbors.Add(transition.TargetStateId);
+            }
+        }
+
+        // BFS from starting state to find maximum shortest-path depth
+        var visited = new HashSet<string>();
+        var queue = new Queue<(string id, int depth)>();
+        queue.Enqueue((machine.StartingStateId, 0));
+        visited.Add(machine.StartingStateId);
+        int maxDepth = 0;
+
+        while (queue.Count > 0)
+        {
+            var (currentId, currentDepth) = queue.Dequeue();
+            if (currentDepth > maxDepth)
+                maxDepth = currentDepth;
+
+            foreach (var neighbor in adjacency[currentId])
+            {
+                if (visited.Add(neighbor))
+                {
+                    queue.Enqueue((neighbor, currentDepth + 1));
+                }
+            }
+        }
+
+        return maxDepth;
+    }
+}

--- a/src/StateMaker.Tests/TestBatteryTests.cs
+++ b/src/StateMaker.Tests/TestBatteryTests.cs
@@ -1,0 +1,249 @@
+using System.Globalization;
+
+namespace StateMaker.Tests;
+
+public class TestBatteryTests
+{
+    #region 3.22 — Test Case Generator Verification
+
+    [Fact]
+    public void GenerateInitialStates_ProducesMultipleStates()
+    {
+        var states = TestCaseGenerator.GenerateInitialStates().ToList();
+
+        Assert.True(states.Count >= 10, $"Expected at least 10 initial states, got {states.Count.ToString(CultureInfo.InvariantCulture)}");
+    }
+
+    [Fact]
+    public void GenerateInitialStates_IncludesEmptyState()
+    {
+        var states = TestCaseGenerator.GenerateInitialStates().ToList();
+
+        Assert.Contains(states, s => s.Variables.Count == 0);
+    }
+
+    [Fact]
+    public void GenerateInitialStates_IncludesAllDataTypes()
+    {
+        var states = TestCaseGenerator.GenerateInitialStates().ToList();
+        var allValues = states.SelectMany(s => s.Variables.Values).ToList();
+
+        Assert.Contains(allValues, v => v is string);
+        Assert.Contains(allValues, v => v is int);
+        Assert.Contains(allValues, v => v is bool);
+        Assert.Contains(allValues, v => v is double);
+    }
+
+    [Fact]
+    public void GenerateConfigs_ProducesMultipleConfigs()
+    {
+        var configs = TestCaseGenerator.GenerateConfigs().ToList();
+
+        Assert.True(configs.Count >= 20, $"Expected at least 20 configs, got {configs.Count.ToString(CultureInfo.InvariantCulture)}");
+    }
+
+    [Fact]
+    public void GenerateConfigs_IncludesBothStrategies()
+    {
+        var configs = TestCaseGenerator.GenerateConfigs().ToList();
+
+        Assert.Contains(configs, c => c.ExplorationStrategy == ExplorationStrategy.BREADTHFIRSTSEARCH);
+        Assert.Contains(configs, c => c.ExplorationStrategy == ExplorationStrategy.DEPTHFIRSTSEARCH);
+    }
+
+    [Fact]
+    public void GenerateConfigs_IncludesNullAndBoundaryLimits()
+    {
+        var configs = TestCaseGenerator.GenerateConfigs().ToList();
+
+        Assert.Contains(configs, c => c.MaxStates is null);
+        Assert.Contains(configs, c => c.MaxStates == 0);
+        Assert.Contains(configs, c => c.MaxStates == -1);
+        Assert.Contains(configs, c => c.MaxStates == 1);
+        Assert.Contains(configs, c => c.MaxDepth is null);
+        Assert.Contains(configs, c => c.MaxDepth == 0);
+        Assert.Contains(configs, c => c.MaxDepth == -1);
+        Assert.Contains(configs, c => c.MaxDepth == 1);
+    }
+
+    [Fact]
+    public void GenerateRuleVariations_ProducesMultipleVariations()
+    {
+        var rules = TestCaseGenerator.GenerateRuleVariations().ToList();
+
+        Assert.True(rules.Count >= 6, $"Expected at least 6 rule variations, got {rules.Count.ToString(CultureInfo.InvariantCulture)}");
+    }
+
+    [Fact]
+    public void GenerateRuleVariations_IncludesEmptyRules()
+    {
+        var rules = TestCaseGenerator.GenerateRuleVariations().ToList();
+
+        Assert.Contains(rules, r => r.Rules.Length == 0);
+    }
+
+    [Fact]
+    public void GenerateAll_ProducesNonEmptyCollection()
+    {
+        var definitions = TestCaseGenerator.GenerateAll().ToList();
+
+        Assert.True(definitions.Count > 100, $"Expected over 100 definitions, got {definitions.Count.ToString(CultureInfo.InvariantCulture)}");
+    }
+
+    [Fact]
+    public void GenerateAll_AllDefinitionsHaveUniqueNames()
+    {
+        var definitions = TestCaseGenerator.GenerateAll().ToList();
+        var names = definitions.Select(d => d.Name).ToList();
+
+        Assert.Equal(names.Count, names.Distinct().Count());
+    }
+
+    [Fact]
+    public void GenerateAll_AllDefinitionsHaveNonNullFields()
+    {
+        var definitions = TestCaseGenerator.GenerateAll().ToList();
+
+        Assert.All(definitions, d =>
+        {
+            Assert.NotNull(d.Name);
+            Assert.NotNull(d.InitialState);
+            Assert.NotNull(d.Rules);
+            Assert.NotNull(d.Config);
+        });
+    }
+
+    #endregion
+
+    #region 3.23 — Test Battery Executor
+
+    [Fact]
+    public void Run_SimpleDefinition_ReturnsPassingResult()
+    {
+        var state = new State();
+        state.Variables["x"] = 0;
+        var definition = new BuildDefinition(
+            "Simple",
+            state,
+            Array.Empty<IRule>(),
+            new BuilderConfig { MaxStates = 10 });
+
+        var result = TestBatteryExecutor.Run(definition);
+
+        Assert.True(result.Passed, result.FailureReason);
+        Assert.Equal(1, result.StateCount);
+        Assert.Equal(0, result.TransitionCount);
+    }
+
+    [Fact]
+    public void Run_ValidMachine_PassesAllOracleChecks()
+    {
+        var state = new State();
+        state.Variables["counter"] = 0;
+        var rules = new IRule[]
+        {
+            new TestFuncRule("Inc",
+                s => (int)s.Variables["counter"]! < 3,
+                s => { var c = s.Clone(); c.Variables["counter"] = (int)c.Variables["counter"]! + 1; return c; })
+        };
+        var definition = new BuildDefinition("Chain3", state, rules, new BuilderConfig { MaxStates = 10, MaxDepth = 5 });
+
+        var result = TestBatteryExecutor.Run(definition);
+
+        Assert.True(result.Passed, result.FailureReason);
+        Assert.Equal(4, result.StateCount);
+        Assert.Equal(3, result.TransitionCount);
+    }
+
+    [Fact]
+    public void Run_MaxStatesRespected_Passes()
+    {
+        var state = new State();
+        state.Variables["counter"] = 0;
+        var rules = new IRule[]
+        {
+            new TestFuncRule("Inc",
+                _ => true,
+                s => { var c = s.Clone(); c.Variables["counter"] = (int)c.Variables["counter"]! + 1; return c; })
+        };
+        var definition = new BuildDefinition("Limited", state, rules, new BuilderConfig { MaxStates = 5 });
+
+        var result = TestBatteryExecutor.Run(definition);
+
+        Assert.True(result.Passed, result.FailureReason);
+        Assert.True(result.StateCount <= 5);
+    }
+
+    [Fact]
+    public void Run_MaxDepthRespected_Passes()
+    {
+        var state = new State();
+        state.Variables["counter"] = 0;
+        var rules = new IRule[]
+        {
+            new TestFuncRule("Inc",
+                _ => true,
+                s => { var c = s.Clone(); c.Variables["counter"] = (int)c.Variables["counter"]! + 1; return c; })
+        };
+        var definition = new BuildDefinition("DepthLimited", state, rules, new BuilderConfig { MaxDepth = 3 });
+
+        var result = TestBatteryExecutor.Run(definition);
+
+        Assert.True(result.Passed, result.FailureReason);
+        Assert.True(result.StateCount <= 4); // depth 0,1,2,3 = 4 states max
+    }
+
+    [Fact]
+    public void RunAll_AllGeneratedDefinitions_PassOracleChecks()
+    {
+        var definitions = TestCaseGenerator.GenerateAll().ToList();
+        var results = TestBatteryExecutor.RunAll(definitions, TimeSpan.FromSeconds(5)).ToList();
+
+        var failures = results.Where(r => !r.Passed).ToList();
+
+        Assert.True(failures.Count == 0,
+            $"{failures.Count.ToString(CultureInfo.InvariantCulture)} of {results.Count.ToString(CultureInfo.InvariantCulture)} definitions failed:\n" +
+            string.Join("\n", failures.Select(f => $"  - {f.DefinitionName}: {f.FailureReason}")));
+    }
+
+    public static IEnumerable<object[]> GeneratedDefinitions()
+    {
+        // Sample a subset for Theory-based granular reporting
+        var definitions = TestCaseGenerator.GenerateAll().ToList();
+        // Take every Nth definition for manageable Theory test count
+        int step = Math.Max(1, definitions.Count / 50);
+        for (int i = 0; i < definitions.Count; i += step)
+        {
+            yield return new object[] { definitions[i] };
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(GeneratedDefinitions))]
+    public void RunSingle_GeneratedDefinition_PassesOracleChecks(BuildDefinition definition)
+    {
+        var result = TestBatteryExecutor.Run(definition, TimeSpan.FromSeconds(5));
+
+        Assert.True(result.Passed, $"{definition.Name}: {result.FailureReason}");
+    }
+
+    #endregion
+
+    private sealed class TestFuncRule : IRule
+    {
+        private readonly string _name;
+        private readonly Func<State, bool> _isAvailable;
+        private readonly Func<State, State> _execute;
+
+        public TestFuncRule(string name, Func<State, bool> isAvailable, Func<State, State> execute)
+        {
+            _name = name;
+            _isAvailable = isAvailable;
+            _execute = execute;
+        }
+
+        public bool IsAvailable(State state) => _isAvailable(state);
+        public State Execute(State state) => _execute(state);
+        public string GetName() => _name;
+    }
+}

--- a/src/StateMaker.Tests/TestCaseGenerator.cs
+++ b/src/StateMaker.Tests/TestCaseGenerator.cs
@@ -1,0 +1,208 @@
+using System.Globalization;
+
+namespace StateMaker.Tests;
+
+public record BuildDefinition(string Name, State InitialState, IRule[] Rules, BuilderConfig Config);
+
+public static class TestCaseGenerator
+{
+    private sealed class FuncRule : IRule
+    {
+        private readonly string _name;
+        private readonly Func<State, bool> _isAvailable;
+        private readonly Func<State, State> _execute;
+
+        public FuncRule(string name, Func<State, bool> isAvailable, Func<State, State> execute)
+        {
+            _name = name;
+            _isAvailable = isAvailable;
+            _execute = execute;
+        }
+
+        public bool IsAvailable(State state) => _isAvailable(state);
+        public State Execute(State state) => _execute(state);
+        public string GetName() => _name;
+    }
+
+    public static IEnumerable<State> GenerateInitialStates()
+    {
+        // Empty state
+        yield return new State();
+
+        // Single string variable
+        var s1 = new State();
+        s1.Variables["status"] = "start";
+        yield return s1;
+
+        // Single int variable
+        var s2 = new State();
+        s2.Variables["counter"] = 0;
+        yield return s2;
+
+        // Single bool variable
+        var s3 = new State();
+        s3.Variables["flag"] = false;
+        yield return s3;
+
+        // Single double variable
+        var s4 = new State();
+        s4.Variables["value"] = 0.0;
+        yield return s4;
+
+        // Multiple variables (string + int + bool)
+        var s5 = new State();
+        s5.Variables["status"] = "init";
+        s5.Variables["counter"] = 0;
+        s5.Variables["active"] = true;
+        yield return s5;
+
+        // N int variables (1..5)
+        for (int n = 1; n <= 5; n++)
+        {
+            var sn = new State();
+            for (int i = 0; i < n; i++)
+            {
+                sn.Variables[$"v{i.ToString(CultureInfo.InvariantCulture)}"] = 0;
+            }
+            yield return sn;
+        }
+    }
+
+    public static IEnumerable<BuilderConfig> GenerateConfigs()
+    {
+        int?[] maxStatesValues = { null, 0, -1, 1, 2, 3, 10 };
+        int?[] maxDepthValues = { null, 0, -1, 1, 2, 3, 10 };
+        ExplorationStrategy[] strategies = { ExplorationStrategy.BREADTHFIRSTSEARCH, ExplorationStrategy.DEPTHFIRSTSEARCH };
+
+        // Pairwise: each MaxStates paired with a subset of MaxDepth values and both strategies
+        // To keep it manageable, pair each MaxStates with null, 0, 1, 3 for MaxDepth, plus both strategies
+        int?[] depthSubset = { null, 0, 1, 3 };
+
+        foreach (var maxStates in maxStatesValues)
+        {
+            foreach (var maxDepth in depthSubset)
+            {
+                foreach (var strategy in strategies)
+                {
+                    yield return new BuilderConfig
+                    {
+                        MaxStates = maxStates,
+                        MaxDepth = maxDepth,
+                        ExplorationStrategy = strategy
+                    };
+                }
+            }
+        }
+
+        // Also include edge-case depth values not in the subset paired with representative MaxStates
+        int?[] statesSubset = { null, 1, 3 };
+        int?[] extraDepths = { -1, 2, 10 };
+        foreach (var maxStates in statesSubset)
+        {
+            foreach (var maxDepth in extraDepths)
+            {
+                yield return new BuilderConfig
+                {
+                    MaxStates = maxStates,
+                    MaxDepth = maxDepth,
+                    ExplorationStrategy = ExplorationStrategy.BREADTHFIRSTSEARCH
+                };
+            }
+        }
+    }
+
+    public static IEnumerable<(string Name, IRule[] Rules)> GenerateRuleVariations()
+    {
+        // Empty rules
+        yield return ("EmptyRules", Array.Empty<IRule>());
+
+        // Never-available rule
+        yield return ("NeverAvailable", new IRule[]
+        {
+            new FuncRule("NeverFires", _ => false, s => s.Clone())
+        });
+
+        // Sets variable to fixed value
+        yield return ("SetsVariable", new IRule[]
+        {
+            new FuncRule("SetStatus",
+                s => s.Variables.ContainsKey("status") && (string)s.Variables["status"]! != "done",
+                s => { var c = s.Clone(); c.Variables["status"] = "done"; return c; })
+        });
+
+        // Adds a new variable
+        yield return ("AddsVariable", new IRule[]
+        {
+            new FuncRule("AddFlag",
+                s => !s.Variables.ContainsKey("added"),
+                s => { var c = s.Clone(); c.Variables["added"] = true; return c; })
+        });
+
+        // Increments int variable
+        yield return ("IncrementsInt", new IRule[]
+        {
+            new FuncRule("Increment",
+                s => s.Variables.ContainsKey("counter") && (int)s.Variables["counter"]! < 10,
+                s => { var c = s.Clone(); c.Variables["counter"] = (int)c.Variables["counter"]! + 1; return c; })
+        });
+
+        // Multiple rules: set + increment
+        yield return ("SetAndIncrement", new IRule[]
+        {
+            new FuncRule("SetStatus",
+                s => s.Variables.ContainsKey("status") && (string)s.Variables["status"]! == "init",
+                s => { var c = s.Clone(); c.Variables["status"] = "running"; return c; }),
+            new FuncRule("Increment",
+                s => s.Variables.ContainsKey("counter") && (int)s.Variables["counter"]! < 5,
+                s => { var c = s.Clone(); c.Variables["counter"] = (int)c.Variables["counter"]! + 1; return c; })
+        });
+
+        // Toggle bool
+        yield return ("ToggleBool", new IRule[]
+        {
+            new FuncRule("Toggle",
+                s => s.Variables.ContainsKey("flag"),
+                s => { var c = s.Clone(); c.Variables["flag"] = !(bool)c.Variables["flag"]!; return c; })
+        });
+    }
+
+    public static IEnumerable<BuildDefinition> GenerateAll()
+    {
+        var states = GenerateInitialStates().ToList();
+        var configs = GenerateConfigs().ToList();
+        var ruleVariations = GenerateRuleVariations().ToList();
+
+        int index = 0;
+        foreach (var initialState in states)
+        {
+            string stateDesc = DescribeState(initialState);
+            foreach (var (ruleName, rules) in ruleVariations)
+            {
+                foreach (var config in configs)
+                {
+                    string configDesc = DescribeConfig(config);
+                    string name = $"[{index.ToString(CultureInfo.InvariantCulture)}] {stateDesc} | {ruleName} | {configDesc}";
+                    // Clone the initial state so each definition has its own copy
+                    yield return new BuildDefinition(name, initialState.Clone(), rules, config);
+                    index++;
+                }
+            }
+        }
+    }
+
+    private static string DescribeState(State state)
+    {
+        if (state.Variables.Count == 0)
+            return "Empty";
+        var keys = string.Join(",", state.Variables.Keys.OrderBy(k => k, StringComparer.Ordinal));
+        return $"Vars({keys})";
+    }
+
+    private static string DescribeConfig(BuilderConfig config)
+    {
+        string ms = config.MaxStates.HasValue ? config.MaxStates.Value.ToString(CultureInfo.InvariantCulture) : "null";
+        string md = config.MaxDepth.HasValue ? config.MaxDepth.Value.ToString(CultureInfo.InvariantCulture) : "null";
+        string strat = config.ExplorationStrategy == ExplorationStrategy.BREADTHFIRSTSEARCH ? "BFS" : "DFS";
+        return $"MS={ms},MD={md},{strat}";
+    }
+}

--- a/tasks/prd-test-generator-battery.md
+++ b/tasks/prd-test-generator-battery.md
@@ -1,0 +1,77 @@
+# PRD: Test Case Generator & Battery Executor (Tasks 3.22, 3.23)
+
+## Objective
+- **Task 3.22**: Implement a test case generator that programmatically combines initial state shapes, config combinations, and rule variations to produce build definitions.
+- **Task 3.23**: Implement a test battery executor that runs build definitions through the builder and applies oracle checks: no crash/exception, no infinite loop (heuristic timeout), MaxStates and MaxDepth limits respected in output.
+
+## Background
+The `StateMachineBuilder` accepts a `State`, `IRule[]`, and `BuilderConfig`. There are many valid combinations of initial state shapes, config limit values, and rule behaviors. Rather than hand-writing every combination, task 3.22 creates a generator that produces `BuildDefinition` objects covering the combinatorial space, and task 3.23 creates an executor that runs them through the builder with automated oracle checks.
+
+## Design
+
+### Task 3.22 — Test Case Generator
+
+#### BuildDefinition Record
+A simple data class holding the inputs to `StateMachineBuilder.Build`:
+- `string Name` — descriptive label for the test case
+- `State InitialState` — the initial state
+- `IRule[] Rules` — the rules array
+- `BuilderConfig Config` — the builder configuration
+
+#### TestCaseGenerator
+A static class with methods that produce `IEnumerable<BuildDefinition>`:
+
+**Initial State Shapes:**
+- No variables (empty state)
+- One string variable
+- One int variable
+- One bool variable
+- One float/double variable
+- Multiple variables (string + int + bool)
+- N variables (1..5 int variables)
+
+**Config Combinations (pairwise):**
+- MaxStates from: null, 0, -1, 1, 2, 3, 10
+- MaxDepth from: null, 0, -1, 1, 2, 3, 10
+- ExplorationStrategy: BFS, DFS
+- Pairwise selection to avoid full combinatorial explosion
+
+**Rule Variations:**
+- Empty rules array
+- Single rule: sets a variable to a fixed value
+- Single rule: adds a new variable
+- Single rule: increments an int variable
+- Multiple rules: set + increment
+- Rule that is never available (always returns false)
+
+**Generator Method:**
+`static IEnumerable<BuildDefinition> GenerateAll()` — produces the cross-product (with pairwise config reduction).
+
+### Task 3.23 — Test Battery Executor
+
+#### TestBatteryExecutor
+A static class that takes `IEnumerable<BuildDefinition>` and runs each through the builder with oracle checks.
+
+**Oracle Checks:**
+1. **No crash/exception**: `Build()` completes without throwing
+2. **No infinite loop**: Wrap `Build()` in a timeout (e.g., 5 seconds) — if exceeded, report as failure
+3. **MaxStates respected**: If `config.MaxStates` is set and positive, `result.States.Count <= config.MaxStates` (with allowance for initial state always being added)
+4. **MaxDepth respected**: If `config.MaxDepth` is set and positive, no state's minimum path length from start exceeds `config.MaxDepth`
+5. **Valid machine**: `result.IsValidMachine()` returns true (when build succeeds)
+
+#### TestBatteryResult
+- `string DefinitionName`
+- `bool Passed`
+- `string? FailureReason`
+- `int StateCount`
+- `int TransitionCount`
+
+#### Integration as xUnit Tests
+- A `[Fact]` test method that generates all definitions, runs the battery, and asserts all pass
+- A `[Theory]` with `MemberData` for individual definition results (for granular reporting)
+
+## Files Modified
+- `src/StateMaker.Tests/TestCaseGenerator.cs` — new file: BuildDefinition, TestCaseGenerator
+- `src/StateMaker.Tests/TestBatteryExecutor.cs` — new file: TestBatteryExecutor, TestBatteryResult
+- `src/StateMaker.Tests/TestBatteryTests.cs` — new file: xUnit tests
+- `tasks/tasks-state-machine-builder.md` — sub-tasks and completion tracking

--- a/tasks/tasks-state-machine-builder.md
+++ b/tasks/tasks-state-machine-builder.md
@@ -154,8 +154,20 @@ All tests must pass before moving on to the next sub-task.
     - [x] 3.21.3 Write tests for combined limits: both MaxStates=1 and MaxDepth=1, MaxStates=2 with MaxDepth=0
     - [x] 3.21.4 Write tests for empty/minimal inputs: empty initial state (no variables), empty rules array with limits set, single rule that is never available
     - [x] 3.21.5 Verify all new edge case and resilience tests pass alongside existing 197+ tests
-  - [ ] 3.22 Implement a test case generator tool that programmatically combines initial state shapes (no variables, one of each data type, multiple variables, 1..N), config combinations (MaxStates x MaxDepth pairwise from null/0/-1/1/2/3/10), and rule variations (sets variable, adds variable, increments, empty) to produce build definition files
-  - [ ] 3.23 Implement a test battery executor tool that runs a set of build definitions through the builder and applies oracle checks: no crash/exception, no infinite loop (heuristic timeout), MaxStates and MaxDepth limits respected in output
+  - [x] 3.22 Implement a test case generator tool that programmatically combines initial state shapes (no variables, one of each data type, multiple variables, 1..N), config combinations (MaxStates x MaxDepth pairwise from null/0/-1/1/2/3/10), and rule variations (sets variable, adds variable, increments, empty) to produce build definition files
+    - [x] 3.22.1 Create `BuildDefinition` record with Name, InitialState, Rules, and Config properties
+    - [x] 3.22.2 Implement initial state shape generators: empty, single string/int/bool/double variable, multiple variables, N int variables (1..5)
+    - [x] 3.22.3 Implement config combination generator with pairwise MaxStates x MaxDepth from null/0/-1/1/2/3/10 and both exploration strategies
+    - [x] 3.22.4 Implement rule variation generators: empty array, sets variable, adds variable, increments int, multiple rules, never-available rule
+    - [x] 3.22.5 Implement `GenerateAll()` method combining state shapes, configs, and rule variations into BuildDefinitions
+  - [x] 3.23 Implement a test battery executor tool that runs a set of build definitions through the builder and applies oracle checks: no crash/exception, no infinite loop (heuristic timeout), MaxStates and MaxDepth limits respected in output
+    - [x] 3.23.1 Create `TestBatteryResult` record with DefinitionName, Passed, FailureReason, StateCount, TransitionCount
+    - [x] 3.23.2 Implement executor that runs each BuildDefinition through StateMachineBuilder.Build with timeout protection
+    - [x] 3.23.3 Implement oracle check: MaxStates limit respected in output (States.Count <= MaxStates when positive)
+    - [x] 3.23.4 Implement oracle check: MaxDepth limit respected via BFS path-length validation
+    - [x] 3.23.5 Implement oracle check: IsValidMachine() returns true for all successful builds
+    - [x] 3.23.6 Write xUnit tests: Theory with MemberData for individual build definition results, Fact for all-pass summary
+    - [x] 3.23.7 Verify all tests pass alongside existing 212+ tests
   - [ ] 3.24 Implement oracle checks in the test battery executor for performance validation: time-to-size ratio within expected bounds, and expected state machine shape matching for tractable cases
   - [ ] 3.25 Implement a reverse rule generator tool that takes a target state machine shape as input and generates one or more sets of rules that would build it, including variations (extra non-triggering rules, different rule orderings) that should not alter the expected output
 


### PR DESCRIPTION
## Summary
- **Task 3.22**: Test case generator that combines 11 initial state shapes, 65 pairwise config combinations (MaxStates x MaxDepth x strategy), and 7 rule variations into BuildDefinition objects
- **Task 3.23**: Battery executor that runs each definition through the builder with 5 oracle checks: no crash, no timeout, MaxStates respected, MaxDepth respected (BFS path-length), IsValidMachine()
- 67 new tests (279 total passing), including a full combinatorial sweep and sampled Theory-based granular reporting

## Test plan
- [x] All 279 tests pass locally via dotnet test
- [ ] Verify CI passes on PR

Generated with [Claude Code](https://claude.com/claude-code)