### PR TITLE
Sync architecture docs and add test tools guide

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,14 @@ Technical architecture documents explaining how the system is designed and how c
 - [**State Immutability**](./architecture/state-immutability.md) - Why immutability matters, the Clone pattern, common mistakes, testing patterns, and correct equality implementation
 - [**Export Formats**](./architecture/export-formats.md) - JSON, DOT, and GraphML export/import specifications, state and transition representation, visualization options, and format comparison
 
+### Test Documentation (`/test`)
+
+Documentation for test plans and test tooling.
+
+**Available Documents:**
+- [**StateMachineBuilder Test Plan**](./test/StateMachineBuilder_test_plan.md) - Test plan covering shapes, rule combinations, and oracle strategies
+- [**Test Tools Guide**](./test/test-tools-guide.md) - How to use TestCaseGenerator, TestBatteryExecutor, and ReverseRuleGenerator for automated state machine testing
+
 ### API Documentation (`/api`)
 *Coming soon* - Auto-generated API documentation from XML comments
 

--- a/docs/architecture/builder-architecture.md
+++ b/docs/architecture/builder-architecture.md
@@ -24,15 +24,16 @@ Before exploration begins, the builder validates inputs:
 Build(initialState, rules, config)
   │
   ├─ Is initialState null?
-  │   └─ YES → throw ArgumentNullException("No initial state provided")
+  │   └─ YES → throw ArgumentNullException
   │
-  ├─ Is config valid?
-  │   ├─ Exhaustive: MaxDepth=null AND MaxStates=null → VALID
-  │   ├─ State-limited: MaxStates set → VALID
-  │   ├─ Dual-limited: Both set → VALID
-  │   ├─ Depth-only: MaxDepth set, MaxStates null → INVALID
-  │   └─ No config: Both null, not exhaustive → INVALID
-  │       └─ throw InvalidOperationException("Invalid configuration: ...")
+  ├─ Is rules null?
+  │   └─ YES → throw ArgumentNullException
+  │
+  ├─ Is config null?
+  │   └─ YES → throw ArgumentNullException
+  │
+  ├─ Does rules contain any null elements?
+  │   └─ YES → throw ArgumentNullException("rules[i]", "Rule at index i is null.")
   │
   └─ Proceed to exploration
 ```
@@ -44,33 +45,32 @@ The builder systematically discovers states using the configured exploration str
 ```
 Initialize:
   - Add initialState to StateMachine as "S0"
-  - Add initialState to exploration queue
-  - Add initialState to visited set (HashSet<State>)
+  - Add initialState to frontier (LinkedList)
+  - Map initialState → "S0" in stateToId (Dictionary<State, string>)
 
 Explore:
-  while queue is not empty:
-    currentState = dequeue next state
+  while frontier is not empty:
+    currentState = remove from frontier (last for DFS, first for BFS)
+
+    if MaxDepth reached for currentState → skip
 
     for each rule in rules:
       if rule.IsAvailable(currentState):
         newState = rule.Execute(currentState)
+        ruleName = rule.GetName()
 
-        if visited contains equivalent state:
+        if stateToId contains equivalent state:
           // Cycle detected - create transition to existing state
-          add Transition(currentState → existingState, rule.GetName())
+          add Transition(currentState → existingState, ruleName)
         else:
+          if MaxStates reached → break out of rule loop
+
           // New state discovered
           assign unique ID to newState
           add newState to StateMachine
-          add newState to visited set
-          add Transition(currentState → newState, rule.GetName())
-
-          if limits not reached:
-            add newState to exploration queue
-
-    check limits:
-      if MaxDepth reached → stop adding states beyond this depth
-      if MaxStates reached → stop exploration entirely
+          map newState → newId in stateToId
+          add Transition(currentState → newState, ruleName)
+          add newState to frontier
 ```
 
 ### 3. Result Assembly
@@ -124,8 +124,11 @@ public class StateMachine
     public string? StartingStateId { get; set; }  // Validates state exists; throws StateDoesNotExistException
     public List<Transition> Transitions { get; }
 
-    public void AddState(string stateId, State state);
+    public void AddOrUpdateState(string stateId, State state);
     public bool RemoveState(string stateId);  // Clears StartingStateId if it matches
+    // Note: RemoveState does not remove transitions referencing the removed state.
+    // It is the caller's responsibility to manage transitions after removal.
+    public bool IsValidMachine();  // True if ≥1 state, non-null StartingStateId, all transitions reference existing states
 }
 ```
 
@@ -154,20 +157,17 @@ public class BuilderConfig
 
 ## State ID Generation
 
-States are assigned unique IDs during exploration:
-- **Default:** Sequential IDs - "S0", "S1", "S2", etc.
-- **Custom:** Via `BuilderConfig.GenerateStateIds` function
-- **Hash-based:** Optional approach using state content hash
+States are assigned sequential unique IDs during exploration: "S0", "S1", "S2", etc.
 
-The initial state is always assigned the first ID (e.g., "S0").
+The initial state is always assigned "S0".
 
 ## Cycle Detection
 
-Cycle detection relies on `State` equality:
+Cycle detection relies on `State` equality via the `stateToId` dictionary:
 
-1. Each new state is checked against the visited set using `State.Equals()` and `State.GetHashCode()`
-2. If an equivalent state exists, a transition is created to the existing state
-3. The duplicate state is NOT added to the exploration queue
+1. Each new state is checked against the `stateToId` dictionary using `State.Equals()` and `State.GetHashCode()`
+2. If an equivalent state exists, a transition is created to the existing state (using its known ID)
+3. The duplicate state is NOT added to the frontier
 4. This prevents infinite loops in state spaces with cycles
 
 ### Example
@@ -179,25 +179,21 @@ S0 (OrderStatus=Pending)
     → RetryOrder  → S0 ← cycle detected, transition to existing S0
 ```
 
-## Logging During Exploration
-
-The builder logs at each phase:
-
-- **INFO:** "Starting exploration from state S0"
-- **INFO:** "Discovered new state S1 via rule ApproveOrder"
-- **INFO:** "Exploration complete: 5 states, 8 transitions"
-- **DEBUG:** "Evaluating rule ApproveOrder against state S0"
-- **DEBUG:** "Rule ApproveOrder is available for state S0"
-- **DEBUG:** "Cycle detected: new state equals existing state S0"
-- **ERROR:** "Rule ApproveOrder threw exception: ..."
-
 ## Performance Considerations
 
-- **HashSet<State>** for O(1) duplicate detection
+- **Dictionary<State, string>** (`stateToId`) for O(1) duplicate detection and state-to-ID mapping
 - Efficient `GetHashCode()` implementation on State is critical
 - Memory grows linearly with number of states
 - `MaxStates` limit is the primary safeguard against memory exhaustion
 - For very large state spaces, consider DFS strategy for lower memory overhead
+
+## Known Behaviors
+
+### Duplicate Transitions
+When two rules with the same `GetName()` produce the same target state from the same source state, the builder creates duplicate transitions (same source, target, and name). This is by design — the builder does not deduplicate transitions.
+
+### Rule Order at MaxStates Boundary
+When `MaxStates` constrains the exploration, rule order can affect the resulting state machine structure. The first rule that generates a new state gets added; subsequent rules that would generate different new states are skipped once the limit is reached. Without `MaxStates` constraints, rule order does not affect the set of states and transitions (though state IDs may differ).
 
 ## Related Documentation
 

--- a/docs/test/test-tools-guide.md
+++ b/docs/test/test-tools-guide.md
@@ -1,0 +1,202 @@
+# Test Tools Guide
+
+This document describes the test tools available in the `StateMaker.Tests` project for generating build definitions, executing test batteries, and verifying state machine shapes.
+
+## Overview
+
+Three test tools work together to enable large-scale, automated testing of `StateMachineBuilder`:
+
+| Tool | Purpose | File |
+|------|---------|------|
+| **TestCaseGenerator** | Generates combinatorial build definitions from initial states, configs, and rule variations | `TestCaseGenerator.cs` |
+| **TestBatteryExecutor** | Runs build definitions through the builder and applies oracle checks | `TestBatteryExecutor.cs` |
+| **ReverseRuleGenerator** | Generates rules that produce known state machine shapes for shape verification | `ReverseRuleGenerator.cs` |
+
+## TestCaseGenerator
+
+Generates `BuildDefinition` instances by combining initial states, builder configurations, and rule variations.
+
+### Records
+
+```csharp
+public record ExpectedShapeInfo(int? ExpectedStateCount, int? ExpectedTransitionCount, int? ExpectedMaxDepth);
+
+public record BuildDefinition(string Name, State InitialState, IRule[] Rules, BuilderConfig Config, ExpectedShapeInfo? ExpectedShape = null);
+```
+
+- `BuildDefinition` is the unit of work for all test tools. It bundles everything needed to build a state machine plus optional expected shape information for oracle verification.
+- `ExpectedShapeInfo` fields are all nullable — only non-null fields are checked by the shape oracle.
+
+### Generator Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `GenerateInitialStates()` | `IEnumerable<State>` | 11 states: empty, single-variable (string, int, bool, double), multi-variable, and 1-5 int variables |
+| `GenerateConfigs()` | `IEnumerable<BuilderConfig>` | ~65 configs combining MaxStates (null,0,-1,1,2,3,10), MaxDepth subsets, and BFS/DFS |
+| `GenerateRuleVariations()` | `IEnumerable<(string, IRule[])>` | 7 variations: empty, never-available, set-variable, add-variable, increment, set-and-increment, toggle-bool |
+| `GenerateAll()` | `IEnumerable<BuildDefinition>` | Cross-product of all states, configs, and rule variations (~5000 definitions) |
+
+### Usage
+
+```csharp
+// Generate all definitions and run through battery
+var definitions = TestCaseGenerator.GenerateAll();
+var results = TestBatteryExecutor.RunAll(definitions);
+foreach (var result in results)
+{
+    Assert.True(result.Passed, $"{result.DefinitionName}: {result.FailureReason}");
+}
+
+// Or use individual generators for targeted testing
+var configs = TestCaseGenerator.GenerateConfigs();
+```
+
+## TestBatteryExecutor
+
+Executes `BuildDefinition` instances and applies a series of oracle checks to the resulting state machine.
+
+### Result Record
+
+```csharp
+public record TestBatteryResult(
+    string DefinitionName,
+    bool Passed,
+    string? FailureReason,
+    int StateCount,
+    int TransitionCount,
+    TimeSpan ElapsedTime);
+```
+
+### Oracle Checks
+
+The executor applies 7 oracle checks in order. If any oracle fails, the result is returned immediately with `Passed = false` and a descriptive `FailureReason`.
+
+| # | Oracle | What it checks |
+|---|--------|----------------|
+| 1 | No crash | Build completes without throwing an exception |
+| 2 | No infinite loop | Build completes within the timeout (default: 5 seconds) |
+| 3 | MaxStates respected | `States.Count <= MaxStates` when MaxStates > 0 |
+| 4 | MaxDepth respected | BFS shortest-path depth from start <= MaxDepth when MaxDepth > 0 |
+| 5 | Valid machine | `IsValidMachine()` returns true |
+| 6 | Performance | Time-to-size ratio does not exceed threshold (default: 100ms/state) |
+| 7 | Shape match | State count, transition count, and max depth match `ExpectedShapeInfo` (when specified) |
+
+### Methods
+
+| Method | Description |
+|--------|-------------|
+| `Run(BuildDefinition)` | Run with default timeout (5s) and performance threshold (100ms/state) |
+| `Run(BuildDefinition, TimeSpan timeout)` | Run with custom timeout |
+| `Run(BuildDefinition, TimeSpan timeout, double msPerStateThreshold)` | Run with custom timeout and performance threshold |
+| `RunAll(IEnumerable<BuildDefinition>)` | Run all definitions with defaults |
+| `RunAll(IEnumerable<BuildDefinition>, TimeSpan timeout)` | Run all definitions with custom timeout |
+
+### Usage
+
+```csharp
+// Single definition
+var result = TestBatteryExecutor.Run(definition);
+Assert.True(result.Passed, result.FailureReason);
+
+// With custom timeout
+var result = TestBatteryExecutor.Run(definition, TimeSpan.FromSeconds(10));
+
+// Batch run
+var results = TestBatteryExecutor.RunAll(definitions);
+var failures = results.Where(r => !r.Passed).ToList();
+Assert.Empty(failures);
+```
+
+## ReverseRuleGenerator
+
+Generates rules designed to produce specific, known state machine shapes. Each shape generator yields multiple `BuildDefinition` variations including the base shape plus rule ordering, split/merge, and non-triggering rule variations.
+
+### Shape Generators
+
+| Method | Shape | States | Transitions | MaxDepth |
+|--------|-------|--------|-------------|----------|
+| `GenerateChain(length)` | S0 → S1 → ... → Sn | length + 1 | length | length |
+| `GenerateCycle(length)` | S0 → S1 → ... → S(n-1) → S0 | length | length | length - 1 |
+| `GenerateChainThenCycle(chainLen, cycleLen)` | Chain followed by cycle | chainLen + cycleLen | chainLen + cycleLen | chainLen + cycleLen - 1 |
+| `GenerateBinaryTree(depth)` | Full binary tree | 2^(depth+1) - 1 | 2^(depth+1) - 2 | depth |
+| `GenerateDiamond(branchCount)` | Root → N branches → converge | branchCount + 2 | branchCount * 2 | 2 |
+| `GenerateFullyConnected(nodeCount)` | Every node → every other | nodeCount | nodeCount * (nodeCount-1) | 1 (if >1 node) |
+
+### Variations
+
+Each shape generator yields multiple `BuildDefinition` instances with these variations:
+
+| Variation | Suffix | Description |
+|-----------|--------|-------------|
+| Base | `_Base` | Original rule set |
+| Non-triggering | `_WithNonTrigger` | Adds a rule with `IsAvailable => false` |
+| Reversed | `_Reversed` | Rules in reverse order (with non-trigger) |
+| Rotated | `_Rotated` | First rule moved to end (for 2+ rules) |
+| Interleaved | `_Interleaved` | Odd/even index reordering (for 3+ rules) |
+| Split | `_Split` | One broad rule decomposed into N per-state specialized rules sharing the same `GetName()` |
+| Split reversed | `_SplitReversed` | Split rules in reverse order |
+| Split shuffled | `_SplitShuffled` | Split rules interleaved with non-triggering rules |
+
+All variations include `ExpectedShapeInfo` so the shape oracle in `TestBatteryExecutor` can verify the resulting state machine matches the expected shape.
+
+### Rule Equivalence Concepts
+
+The variations test three axes of rule set equivalence:
+
+1. **Rule ordering**: Different orderings of the same rules produce the same state machine (when MaxStates does not constrain). State IDs may differ but the topology is identical.
+
+2. **Rule split/merge**: A single rule that handles N state values can be replaced by N specialized rules, each handling one value but all sharing the same `GetName()`. The resulting state machine is identical.
+
+3. **Non-triggering rules**: Adding rules that never fire (`IsAvailable => false`) does not change the resulting state machine.
+
+### Usage
+
+```csharp
+// Generate all shapes and variations
+var allShapes = ReverseRuleGenerator.GenerateAllShapes();
+foreach (var definition in allShapes)
+{
+    var result = TestBatteryExecutor.Run(definition);
+    Assert.True(result.Passed, $"{definition.Name}: {result.FailureReason}");
+}
+
+// Generate a specific shape
+var chains = ReverseRuleGenerator.GenerateChain(5);
+foreach (var def in chains)
+{
+    var result = TestBatteryExecutor.Run(def);
+    Assert.True(result.Passed, result.FailureReason);
+}
+```
+
+### `GenerateAllShapes()` Coverage
+
+`GenerateAllShapes()` produces definitions for all shapes at various sizes:
+
+- Chains: lengths 1, 3, 5, 10
+- Cycles: lengths 2, 3, 5
+- Chain-then-cycle: (1,2), (2,3), (3,3)
+- Binary trees: depths 1, 2, 3
+- Diamonds: 2, 3, 4 branches
+- Fully connected: 2, 3, 4 nodes
+
+## Combining the Tools
+
+The tools are designed to work together. `TestCaseGenerator` produces broad combinatorial coverage, while `ReverseRuleGenerator` produces targeted shape-specific definitions. Both produce `BuildDefinition` records that `TestBatteryExecutor` can run.
+
+```csharp
+// Combinatorial coverage (broad, oracle-based)
+var combinatorial = TestCaseGenerator.GenerateAll();
+
+// Shape-specific coverage (targeted, shape-verified)
+var shapes = ReverseRuleGenerator.GenerateAllShapes();
+
+// Run everything through the same executor
+var allDefinitions = combinatorial.Concat(shapes);
+var results = TestBatteryExecutor.RunAll(allDefinitions);
+```
+
+## Related Documentation
+
+- [StateMachineBuilder Test Plan](./StateMachineBuilder_test_plan.md)
+- [Builder Architecture](../architecture/builder-architecture.md)


### PR DESCRIPTION
## Summary
- Sync builder-architecture.md with current code (stateToId Dictionary, AddOrUpdateState, validation phase, Known Behaviors)
- Update test plan data structures and add link to test tools
- Add test-tools-guide.md documenting TestCaseGenerator, TestBatteryExecutor, ReverseRuleGenerator
- Add Test Documentation section to docs README

## Test plan
- [x] Build succeeds with no warnings or errors
- [x] No code changes, documentation only

Generated with [Claude Code](https://claude.com/claude-code)