### PR TITLE
Add declarative rules, JSON file loader, and RuleBuilder API

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,5 +3,6 @@
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisLevel>latest-recommended</AnalysisLevel>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 </Project>

--- a/src/StateMaker.Tests/DeclarativeRuleTests.cs
+++ b/src/StateMaker.Tests/DeclarativeRuleTests.cs
@@ -1,0 +1,280 @@
+namespace StateMaker.Tests;
+
+public class DeclarativeRuleTests
+{
+    private readonly ExpressionEvaluator _evaluator = new();
+
+    private static Dictionary<string, string> Transforms(params (string key, string expr)[] pairs)
+    {
+        var dict = new Dictionary<string, string>();
+        foreach (var (key, expr) in pairs)
+            dict[key] = expr;
+        return dict;
+    }
+
+    private static State MakeState(params (string key, object value)[] pairs)
+    {
+        var state = new State();
+        foreach (var (key, value) in pairs)
+            state.Variables[key] = value;
+        return state;
+    }
+
+    #region 6.1 — Construction and GetName
+
+    [Fact]
+    public void GetName_ReturnsConfiguredName()
+    {
+        var rule = new DeclarativeRule("MyRule", "true", Transforms(), _evaluator);
+        Assert.Equal("MyRule", rule.GetName());
+    }
+
+    [Fact]
+    public void Constructor_NullName_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            new DeclarativeRule(null!, "true", Transforms(), _evaluator));
+    }
+
+    [Fact]
+    public void Constructor_NullCondition_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            new DeclarativeRule("Rule", null!, Transforms(), _evaluator));
+    }
+
+    [Fact]
+    public void Constructor_NullTransformations_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            new DeclarativeRule("Rule", "true", null!, _evaluator));
+    }
+
+    [Fact]
+    public void Constructor_NullEvaluator_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            new DeclarativeRule("Rule", "true", Transforms(), null!));
+    }
+
+    #endregion
+
+    #region 6.2 — IsAvailable
+
+    [Fact]
+    public void IsAvailable_ConditionTrue_ReturnsTrue()
+    {
+        var rule = new DeclarativeRule("Rule", "[Status] == 'Pending'",
+            Transforms(), _evaluator);
+        var state = MakeState(("Status", "Pending"));
+        Assert.True(rule.IsAvailable(state));
+    }
+
+    [Fact]
+    public void IsAvailable_ConditionFalse_ReturnsFalse()
+    {
+        var rule = new DeclarativeRule("Rule", "[Status] == 'Pending'",
+            Transforms(), _evaluator);
+        var state = MakeState(("Status", "Approved"));
+        Assert.False(rule.IsAvailable(state));
+    }
+
+    [Fact]
+    public void IsAvailable_CompoundCondition_ReturnsTrue()
+    {
+        var rule = new DeclarativeRule("Rule",
+            "[Status] == 'Pending' && [Amount] < 1000",
+            Transforms(), _evaluator);
+        var state = MakeState(("Status", "Pending"), ("Amount", 500));
+        Assert.True(rule.IsAvailable(state));
+    }
+
+    [Fact]
+    public void IsAvailable_CompoundCondition_ReturnsFalse()
+    {
+        var rule = new DeclarativeRule("Rule",
+            "[Status] == 'Pending' && [Amount] < 1000",
+            Transforms(), _evaluator);
+        var state = MakeState(("Status", "Pending"), ("Amount", 1500));
+        Assert.False(rule.IsAvailable(state));
+    }
+
+    [Fact]
+    public void IsAvailable_AlwaysTrue_ReturnsTrue()
+    {
+        var rule = new DeclarativeRule("Rule", "true", Transforms(), _evaluator);
+        var state = MakeState(("x", 1));
+        Assert.True(rule.IsAvailable(state));
+    }
+
+    [Fact]
+    public void IsAvailable_BooleanVariable_Works()
+    {
+        var rule = new DeclarativeRule("Rule", "[IsActive] == true",
+            Transforms(), _evaluator);
+        var state = MakeState(("IsActive", true));
+        Assert.True(rule.IsAvailable(state));
+    }
+
+    #endregion
+
+    #region 6.3 — Execute
+
+    [Fact]
+    public void Execute_SingleTransformation_SetsValue()
+    {
+        var rule = new DeclarativeRule("Approve", "[Status] == 'Pending'",
+            Transforms(("Status", "'Approved'")), _evaluator);
+        var state = MakeState(("Status", "Pending"));
+
+        var result = rule.Execute(state);
+
+        Assert.Equal("Approved", result.Variables["Status"]);
+    }
+
+    [Fact]
+    public void Execute_MultipleTransformations_SetsAllValues()
+    {
+        var rule = new DeclarativeRule("Process", "true",
+            Transforms(("Status", "'Processed'"), ("Count", "[Count] + 1")),
+            _evaluator);
+        var state = MakeState(("Status", "Pending"), ("Count", 5));
+
+        var result = rule.Execute(state);
+
+        Assert.Equal("Processed", result.Variables["Status"]);
+        Assert.Equal(6, result.Variables["Count"]);
+    }
+
+    [Fact]
+    public void Execute_TransformationUsesOriginalState_NotIntermediateValues()
+    {
+        // Both transformations should read from the original state
+        // If x=1, y=2: newX = y (should be 2), newY = x (should be 1)
+        var rule = new DeclarativeRule("Swap", "true",
+            Transforms(("x", "[y]"), ("y", "[x]")),
+            _evaluator);
+        var state = MakeState(("x", 1), ("y", 2));
+
+        var result = rule.Execute(state);
+
+        Assert.Equal(2, result.Variables["x"]);
+        Assert.Equal(1, result.Variables["y"]);
+    }
+
+    [Fact]
+    public void Execute_InputStateNotMutated()
+    {
+        var rule = new DeclarativeRule("Increment", "true",
+            Transforms(("Count", "[Count] + 1")), _evaluator);
+        var state = MakeState(("Count", 5));
+
+        rule.Execute(state);
+
+        Assert.Equal(5, state.Variables["Count"]);
+    }
+
+    [Fact]
+    public void Execute_ArithmeticTransformation()
+    {
+        var rule = new DeclarativeRule("Double", "true",
+            Transforms(("Value", "[Value] * 2")), _evaluator);
+        var state = MakeState(("Value", 10));
+
+        var result = rule.Execute(state);
+
+        Assert.Equal(20, result.Variables["Value"]);
+    }
+
+    [Fact]
+    public void Execute_NoTransformations_ReturnsClone()
+    {
+        var rule = new DeclarativeRule("NoOp", "true", Transforms(), _evaluator);
+        var state = MakeState(("x", 1));
+
+        var result = rule.Execute(state);
+
+        Assert.Equal(state, result);
+        Assert.NotSame(state, result);
+    }
+
+    [Fact]
+    public void Execute_AddsNewVariable()
+    {
+        var rule = new DeclarativeRule("AddVar", "true",
+            Transforms(("NewVar", "'hello'")), _evaluator);
+        var state = MakeState(("x", 1));
+
+        var result = rule.Execute(state);
+
+        Assert.Equal("hello", result.Variables["NewVar"]);
+        Assert.Equal(1, result.Variables["x"]);
+    }
+
+    [Fact]
+    public void Execute_BooleanTransformation()
+    {
+        var rule = new DeclarativeRule("Deactivate", "true",
+            Transforms(("IsActive", "false")), _evaluator);
+        var state = MakeState(("IsActive", true));
+
+        var result = rule.Execute(state);
+
+        Assert.Equal(false, result.Variables["IsActive"]);
+    }
+
+    #endregion
+
+    #region 6.3 — Execute Error Cases
+
+    [Fact]
+    public void Execute_InvalidTransformationExpression_Throws()
+    {
+        var rule = new DeclarativeRule("Bad", "true",
+            Transforms(("x", "=== invalid ===")), _evaluator);
+        var state = MakeState(("x", 1));
+
+        Assert.Throws<InvalidOperationException>(() => rule.Execute(state));
+    }
+
+    [Fact]
+    public void IsAvailable_InvalidCondition_Throws()
+    {
+        var rule = new DeclarativeRule("Bad", "=== invalid ===",
+            Transforms(), _evaluator);
+        var state = MakeState(("x", 1));
+
+        Assert.Throws<InvalidOperationException>(() => rule.IsAvailable(state));
+    }
+
+    #endregion
+
+    #region IRule Contract
+
+    [Fact]
+    public void ImplementsIRule()
+    {
+        var rule = new DeclarativeRule("Rule", "true", Transforms(), _evaluator);
+        Assert.IsAssignableFrom<IRule>(rule);
+    }
+
+    [Fact]
+    public void WorksWithStateMachineBuilder()
+    {
+        // Integration: DeclarativeRule works with the builder to produce a state machine
+        var rule = new DeclarativeRule("Increment", "[step] < 3",
+            Transforms(("step", "[step] + 1")), _evaluator);
+        var initialState = MakeState(("step", 0));
+        var config = new BuilderConfig { MaxStates = 10 };
+
+        var builder = new StateMachineBuilder();
+        var machine = builder.Build(initialState, new IRule[] { rule }, config);
+
+        // Should produce states: step=0, step=1, step=2, step=3
+        Assert.Equal(4, machine.States.Count);
+        Assert.Equal(3, machine.Transitions.Count);
+        Assert.True(machine.IsValidMachine());
+    }
+
+    #endregion
+}

--- a/src/StateMaker.Tests/RuleBuilderTests.cs
+++ b/src/StateMaker.Tests/RuleBuilderTests.cs
@@ -1,0 +1,107 @@
+namespace StateMaker.Tests;
+
+public class RuleBuilderTests
+{
+    private static Dictionary<string, string> Transforms(params (string key, string expr)[] pairs)
+    {
+        var dict = new Dictionary<string, string>();
+        foreach (var (key, expr) in pairs)
+            dict[key] = expr;
+        return dict;
+    }
+
+    private static State MakeState(params (string key, object value)[] pairs)
+    {
+        var state = new State();
+        foreach (var (key, value) in pairs)
+            state.Variables[key] = value;
+        return state;
+    }
+
+    [Fact]
+    public void DefineRule_CreatesDeclarativeRule()
+    {
+        var rule = RuleBuilder.DefineRule("MyRule", "true", Transforms(("x", "1")));
+
+        Assert.IsType<DeclarativeRule>(rule);
+        Assert.Equal("MyRule", rule.GetName());
+    }
+
+    [Fact]
+    public void DefineRule_RuleIsAvailable_Works()
+    {
+        var rule = RuleBuilder.DefineRule("Check", "[x] > 0", Transforms());
+        var state = MakeState(("x", 5));
+
+        Assert.True(rule.IsAvailable(state));
+    }
+
+    [Fact]
+    public void DefineRule_RuleExecute_Works()
+    {
+        var rule = RuleBuilder.DefineRule("Increment", "true",
+            Transforms(("Count", "[Count] + 1")));
+        var state = MakeState(("Count", 10));
+
+        var result = rule.Execute(state);
+
+        Assert.Equal(11, result.Variables["Count"]);
+    }
+
+    [Fact]
+    public void DefineRule_WithCustomEvaluator_UsesIt()
+    {
+        var evaluator = new ExpressionEvaluator();
+        var rule = RuleBuilder.DefineRule("Rule", "[x] == 1",
+            Transforms(("x", "2")), evaluator);
+
+        var state = MakeState(("x", 1));
+        Assert.True(rule.IsAvailable(state));
+
+        var result = rule.Execute(state);
+        Assert.Equal(2, result.Variables["x"]);
+    }
+
+    [Fact]
+    public void DefineRule_ImplementsIRule()
+    {
+        var rule = RuleBuilder.DefineRule("Rule", "true", Transforms());
+        Assert.IsAssignableFrom<IRule>(rule);
+    }
+
+    [Fact]
+    public void DefineRule_WorksWithBuilder()
+    {
+        var rule = RuleBuilder.DefineRule("Step", "[step] < 2",
+            Transforms(("step", "[step] + 1")));
+        var initialState = MakeState(("step", 0));
+        var config = new BuilderConfig { MaxStates = 10 };
+
+        var builder = new StateMachineBuilder();
+        var machine = builder.Build(initialState, new IRule[] { rule }, config);
+
+        Assert.Equal(3, machine.States.Count);
+        Assert.Equal(2, machine.Transitions.Count);
+        Assert.True(machine.IsValidMachine());
+    }
+
+    [Fact]
+    public void DefineRule_MultipleRules_WorkTogether()
+    {
+        var approve = RuleBuilder.DefineRule("Approve", "[Status] == 'Pending'",
+            Transforms(("Status", "'Approved'")));
+        var close = RuleBuilder.DefineRule("Close", "[Status] == 'Approved'",
+            Transforms(("Status", "'Closed'")));
+
+        var initialState = MakeState(("Status", "Pending"));
+        var config = new BuilderConfig { MaxStates = 10 };
+
+        var builder = new StateMachineBuilder();
+        var machine = builder.Build(initialState, new IRule[] { approve, close }, config);
+
+        // Pending -> Approved -> Closed
+        Assert.Equal(3, machine.States.Count);
+        Assert.Equal(2, machine.Transitions.Count);
+        Assert.True(machine.IsValidMachine());
+    }
+}

--- a/src/StateMaker.Tests/RuleFileLoaderTests.cs
+++ b/src/StateMaker.Tests/RuleFileLoaderTests.cs
@@ -1,5 +1,3 @@
-using System.IO;
-
 namespace StateMaker.Tests;
 
 public class RuleFileLoaderTests
@@ -20,9 +18,9 @@ public class RuleFileLoaderTests
 
         Assert.NotNull(initialState);
         Assert.Equal("Pending", initialState!.Variables["Status"]);
-        Assert.Equal(0, Convert.ToInt32(initialState.Variables["Count"]));
+        Assert.Equal(0, (int)initialState.Variables["Count"]!);
         Assert.Equal(true, initialState.Variables["IsActive"]);
-        Assert.Equal(9.99, Convert.ToDouble(initialState.Variables["Price"]));
+        Assert.Equal(9.99, (double)initialState.Variables["Price"]!);
     }
 
     [Fact]
@@ -443,7 +441,7 @@ public class RuleFileLoaderTests
             var (initialState, rules) = _loader.LoadFromFile(tempFile);
 
             Assert.NotNull(initialState);
-            Assert.Equal(0, Convert.ToInt32(initialState!.Variables["x"]));
+            Assert.Equal(0, (int)initialState!.Variables["x"]!);
             Assert.Single(rules);
             Assert.Equal("Inc", rules[0].GetName());
         }

--- a/src/StateMaker.Tests/RuleFileLoaderTests.cs
+++ b/src/StateMaker.Tests/RuleFileLoaderTests.cs
@@ -1,0 +1,516 @@
+using System.IO;
+
+namespace StateMaker.Tests;
+
+public class RuleFileLoaderTests
+{
+    private readonly RuleFileLoader _loader = new(new ExpressionEvaluator());
+
+    #region 6.6 — Initial State Parsing
+
+    [Fact]
+    public void LoadFromJson_WithInitialState_ReturnsState()
+    {
+        var json = @"{
+            ""initialState"": { ""Status"": ""Pending"", ""Count"": 0, ""IsActive"": true, ""Price"": 9.99 },
+            ""rules"": []
+        }";
+
+        var (initialState, _) = _loader.LoadFromJson(json);
+
+        Assert.NotNull(initialState);
+        Assert.Equal("Pending", initialState!.Variables["Status"]);
+        Assert.Equal(0, Convert.ToInt32(initialState.Variables["Count"]));
+        Assert.Equal(true, initialState.Variables["IsActive"]);
+        Assert.Equal(9.99, Convert.ToDouble(initialState.Variables["Price"]));
+    }
+
+    [Fact]
+    public void LoadFromJson_WithoutInitialState_ReturnsNull()
+    {
+        var json = @"{ ""rules"": [] }";
+
+        var (initialState, _) = _loader.LoadFromJson(json);
+
+        Assert.Null(initialState);
+    }
+
+    [Fact]
+    public void LoadFromJson_NullInitialState_ReturnsNull()
+    {
+        var json = @"{ ""initialState"": null, ""rules"": [] }";
+
+        var (initialState, _) = _loader.LoadFromJson(json);
+
+        Assert.Null(initialState);
+    }
+
+    #endregion
+
+    #region 6.7 — Declarative Rule Parsing
+
+    [Fact]
+    public void LoadFromJson_SingleDeclarativeRule_CreatesRule()
+    {
+        var json = @"{
+            ""rules"": [
+                {
+                    ""name"": ""ApproveRule"",
+                    ""condition"": ""[Status] == 'Pending'"",
+                    ""transformations"": { ""Status"": ""'Approved'"" }
+                }
+            ]
+        }";
+
+        var (_, rules) = _loader.LoadFromJson(json);
+
+        Assert.Single(rules);
+        Assert.IsType<DeclarativeRule>(rules[0]);
+        Assert.Equal("ApproveRule", rules[0].GetName());
+    }
+
+    [Fact]
+    public void LoadFromJson_DeclarativeRuleWithExplicitType_CreatesRule()
+    {
+        var json = @"{
+            ""rules"": [
+                {
+                    ""type"": ""declarative"",
+                    ""name"": ""MyRule"",
+                    ""condition"": ""true"",
+                    ""transformations"": { ""x"": ""1"" }
+                }
+            ]
+        }";
+
+        var (_, rules) = _loader.LoadFromJson(json);
+
+        Assert.Single(rules);
+        Assert.IsType<DeclarativeRule>(rules[0]);
+        Assert.Equal("MyRule", rules[0].GetName());
+    }
+
+    [Fact]
+    public void LoadFromJson_MultipleDeclarativeRules_CreatesAll()
+    {
+        var json = @"{
+            ""rules"": [
+                {
+                    ""name"": ""Rule1"",
+                    ""condition"": ""true"",
+                    ""transformations"": { ""x"": ""1"" }
+                },
+                {
+                    ""name"": ""Rule2"",
+                    ""condition"": ""[x] == 1"",
+                    ""transformations"": { ""x"": ""2"" }
+                }
+            ]
+        }";
+
+        var (_, rules) = _loader.LoadFromJson(json);
+
+        Assert.Equal(2, rules.Length);
+        Assert.Equal("Rule1", rules[0].GetName());
+        Assert.Equal("Rule2", rules[1].GetName());
+    }
+
+    [Fact]
+    public void LoadFromJson_DeclarativeRuleWithMultipleTransformations()
+    {
+        var json = @"{
+            ""rules"": [
+                {
+                    ""name"": ""Process"",
+                    ""condition"": ""true"",
+                    ""transformations"": { ""Status"": ""'Done'"", ""Count"": ""[Count] + 1"" }
+                }
+            ]
+        }";
+
+        var (_, rules) = _loader.LoadFromJson(json);
+        var state = new State();
+        state.Variables["Status"] = "Pending";
+        state.Variables["Count"] = 5;
+
+        var result = rules[0].Execute(state);
+        Assert.Equal("Done", result.Variables["Status"]);
+        Assert.Equal(6, result.Variables["Count"]);
+    }
+
+    [Fact]
+    public void LoadFromJson_DeclarativeRuleWithEmptyTransformations()
+    {
+        var json = @"{
+            ""rules"": [
+                {
+                    ""name"": ""NoOp"",
+                    ""condition"": ""true"",
+                    ""transformations"": {}
+                }
+            ]
+        }";
+
+        var (_, rules) = _loader.LoadFromJson(json);
+        Assert.Single(rules);
+    }
+
+    #endregion
+
+    #region 6.7 — Declarative Rule Functional Verification
+
+    [Fact]
+    public void LoadFromJson_RuleIsAvailable_EvaluatesCondition()
+    {
+        var json = @"{
+            ""rules"": [
+                {
+                    ""name"": ""CheckStatus"",
+                    ""condition"": ""[Status] == 'Pending'"",
+                    ""transformations"": { ""Status"": ""'Approved'"" }
+                }
+            ]
+        }";
+
+        var (_, rules) = _loader.LoadFromJson(json);
+        var pendingState = new State();
+        pendingState.Variables["Status"] = "Pending";
+        var approvedState = new State();
+        approvedState.Variables["Status"] = "Approved";
+
+        Assert.True(rules[0].IsAvailable(pendingState));
+        Assert.False(rules[0].IsAvailable(approvedState));
+    }
+
+    #endregion
+
+    #region 6.8 — Custom Rule Loading
+
+    [Fact]
+    public void LoadFromJson_CustomRule_LoadsFromAssembly()
+    {
+        // Use the test assembly itself which contains IRule implementations
+        var assemblyPath = typeof(RuleFileLoaderTests).Assembly.Location;
+        var className = typeof(TestCustomRule).FullName;
+
+        var json = $@"{{
+            ""rules"": [
+                {{
+                    ""type"": ""custom"",
+                    ""assemblyPath"": ""{assemblyPath.Replace("\\", "\\\\")}"",
+                    ""className"": ""{className}""
+                }}
+            ]
+        }}";
+
+        var (_, rules) = _loader.LoadFromJson(json);
+
+        Assert.Single(rules);
+        Assert.IsType<TestCustomRule>(rules[0]);
+    }
+
+    [Fact]
+    public void LoadFromJson_MixedRules_LoadsBothTypes()
+    {
+        var assemblyPath = typeof(RuleFileLoaderTests).Assembly.Location;
+        var className = typeof(TestCustomRule).FullName;
+
+        var json = $@"{{
+            ""rules"": [
+                {{
+                    ""name"": ""DeclRule"",
+                    ""condition"": ""true"",
+                    ""transformations"": {{ ""x"": ""1"" }}
+                }},
+                {{
+                    ""type"": ""custom"",
+                    ""assemblyPath"": ""{assemblyPath.Replace("\\", "\\\\")}"",
+                    ""className"": ""{className}""
+                }}
+            ]
+        }}";
+
+        var (_, rules) = _loader.LoadFromJson(json);
+
+        Assert.Equal(2, rules.Length);
+        Assert.IsType<DeclarativeRule>(rules[0]);
+        Assert.IsType<TestCustomRule>(rules[1]);
+    }
+
+    #endregion
+
+    #region 6.9 — Validation and Error Messages
+
+    [Fact]
+    public void LoadFromJson_InvalidJson_Throws()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            _loader.LoadFromJson("not valid json {{{"));
+        Assert.Contains("JSON", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void LoadFromJson_MissingRulesArray_Throws()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            _loader.LoadFromJson(@"{ ""initialState"": {} }"));
+        Assert.Contains("rules", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void LoadFromJson_DeclarativeRule_MissingName_Throws()
+    {
+        var json = @"{
+            ""rules"": [
+                {
+                    ""condition"": ""true"",
+                    ""transformations"": { ""x"": ""1"" }
+                }
+            ]
+        }";
+
+        var ex = Assert.Throws<InvalidOperationException>(() => _loader.LoadFromJson(json));
+        Assert.Contains("name", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void LoadFromJson_DeclarativeRule_MissingCondition_Throws()
+    {
+        var json = @"{
+            ""rules"": [
+                {
+                    ""name"": ""Rule1"",
+                    ""transformations"": { ""x"": ""1"" }
+                }
+            ]
+        }";
+
+        var ex = Assert.Throws<InvalidOperationException>(() => _loader.LoadFromJson(json));
+        Assert.Contains("condition", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void LoadFromJson_CustomRule_MissingClassName_Throws()
+    {
+        var json = @"{
+            ""rules"": [
+                {
+                    ""type"": ""custom"",
+                    ""assemblyPath"": ""some.dll""
+                }
+            ]
+        }";
+
+        var ex = Assert.Throws<InvalidOperationException>(() => _loader.LoadFromJson(json));
+        Assert.Contains("className", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void LoadFromJson_CustomRule_MissingAssemblyPath_Throws()
+    {
+        var json = @"{
+            ""rules"": [
+                {
+                    ""type"": ""custom"",
+                    ""className"": ""Some.Class""
+                }
+            ]
+        }";
+
+        var ex = Assert.Throws<InvalidOperationException>(() => _loader.LoadFromJson(json));
+        Assert.Contains("assemblyPath", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void LoadFromJson_CustomRule_AssemblyNotFound_Throws()
+    {
+        var json = @"{
+            ""rules"": [
+                {
+                    ""type"": ""custom"",
+                    ""assemblyPath"": ""nonexistent.dll"",
+                    ""className"": ""Some.Class""
+                }
+            ]
+        }";
+
+        var ex = Assert.Throws<InvalidOperationException>(() => _loader.LoadFromJson(json));
+        Assert.Contains("assembly", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void LoadFromJson_CustomRule_ClassNotFound_Throws()
+    {
+        var assemblyPath = typeof(RuleFileLoaderTests).Assembly.Location;
+
+        var json = $@"{{
+            ""rules"": [
+                {{
+                    ""type"": ""custom"",
+                    ""assemblyPath"": ""{assemblyPath.Replace("\\", "\\\\")}"",
+                    ""className"": ""NonExistent.ClassName""
+                }}
+            ]
+        }}";
+
+        var ex = Assert.Throws<InvalidOperationException>(() => _loader.LoadFromJson(json));
+        Assert.Contains("not found", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void LoadFromJson_CustomRule_DoesNotImplementIRule_Throws()
+    {
+        var assemblyPath = typeof(RuleFileLoaderTests).Assembly.Location;
+        var className = typeof(NotARuleClass).FullName;
+
+        var json = $@"{{
+            ""rules"": [
+                {{
+                    ""type"": ""custom"",
+                    ""assemblyPath"": ""{assemblyPath.Replace("\\", "\\\\")}"",
+                    ""className"": ""{className}""
+                }}
+            ]
+        }}";
+
+        var ex = Assert.Throws<InvalidOperationException>(() => _loader.LoadFromJson(json));
+        Assert.Contains("IRule", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void LoadFromJson_CustomRule_NoParameterlessConstructor_Throws()
+    {
+        var assemblyPath = typeof(RuleFileLoaderTests).Assembly.Location;
+        var className = typeof(NoDefaultConstructorRule).FullName;
+
+        var json = $@"{{
+            ""rules"": [
+                {{
+                    ""type"": ""custom"",
+                    ""assemblyPath"": ""{assemblyPath.Replace("\\", "\\\\")}"",
+                    ""className"": ""{className}""
+                }}
+            ]
+        }}";
+
+        var ex = Assert.Throws<InvalidOperationException>(() => _loader.LoadFromJson(json));
+        Assert.Contains("constructor", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void LoadFromJson_UnknownRuleType_Throws()
+    {
+        var json = @"{
+            ""rules"": [
+                {
+                    ""type"": ""unknown"",
+                    ""name"": ""Rule1""
+                }
+            ]
+        }";
+
+        var ex = Assert.Throws<InvalidOperationException>(() => _loader.LoadFromJson(json));
+        Assert.Contains("unknown", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void LoadFromJson_NullJson_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => _loader.LoadFromJson(null!));
+    }
+
+    #endregion
+
+    #region 6.5 — File Loading
+
+    [Fact]
+    public void LoadFromFile_ValidFile_LoadsRules()
+    {
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(tempFile, @"{
+                ""initialState"": { ""x"": 0 },
+                ""rules"": [
+                    {
+                        ""name"": ""Inc"",
+                        ""condition"": ""[x] < 3"",
+                        ""transformations"": { ""x"": ""[x] + 1"" }
+                    }
+                ]
+            }");
+
+            var (initialState, rules) = _loader.LoadFromFile(tempFile);
+
+            Assert.NotNull(initialState);
+            Assert.Equal(0, Convert.ToInt32(initialState!.Variables["x"]));
+            Assert.Single(rules);
+            Assert.Equal("Inc", rules[0].GetName());
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public void LoadFromFile_FileNotFound_Throws()
+    {
+        var ex = Assert.Throws<FileNotFoundException>(() =>
+            _loader.LoadFromFile("/nonexistent/path/rules.json"));
+    }
+
+    #endregion
+
+    #region Integration
+
+    [Fact]
+    public void LoadFromJson_FullIntegration_ProducesStateMachine()
+    {
+        var json = @"{
+            ""initialState"": { ""step"": 0 },
+            ""rules"": [
+                {
+                    ""name"": ""Increment"",
+                    ""condition"": ""[step] < 3"",
+                    ""transformations"": { ""step"": ""[step] + 1"" }
+                }
+            ]
+        }";
+
+        var (initialState, rules) = _loader.LoadFromJson(json);
+        var builder = new StateMachineBuilder();
+        var machine = builder.Build(initialState!, rules, new BuilderConfig { MaxStates = 10 });
+
+        Assert.Equal(4, machine.States.Count);
+        Assert.Equal(3, machine.Transitions.Count);
+        Assert.True(machine.IsValidMachine());
+    }
+
+    #endregion
+}
+
+// Test helper classes for custom rule loading tests
+public class TestCustomRule : IRule
+{
+    public bool IsAvailable(State state) => true;
+    public State Execute(State state) => state.Clone();
+}
+
+public class NotARuleClass
+{
+    public string Name { get; set; } = "NotARule";
+}
+
+public class NoDefaultConstructorRule : IRule
+{
+    private readonly string _value;
+
+    public NoDefaultConstructorRule(string value)
+    {
+        _value = value;
+    }
+
+    public bool IsAvailable(State state) => true;
+    public State Execute(State state) => state.Clone();
+}

--- a/src/StateMaker/DeclarativeRule.cs
+++ b/src/StateMaker/DeclarativeRule.cs
@@ -1,0 +1,59 @@
+namespace StateMaker;
+
+public class DeclarativeRule : IRule
+{
+    private readonly string _name;
+    private readonly string _condition;
+    private readonly Dictionary<string, string> _transformations;
+    private readonly IExpressionEvaluator _evaluator;
+
+    public DeclarativeRule(
+        string name,
+        string condition,
+        Dictionary<string, string> transformations,
+        IExpressionEvaluator evaluator)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+        ArgumentNullException.ThrowIfNull(condition);
+        ArgumentNullException.ThrowIfNull(transformations);
+        ArgumentNullException.ThrowIfNull(evaluator);
+
+        _name = name;
+        _condition = condition;
+        _transformations = transformations;
+        _evaluator = evaluator;
+    }
+
+    public bool IsAvailable(State state)
+    {
+        var variables = GetNonNullableVariables(state);
+        return _evaluator.EvaluateBoolean(_condition, variables);
+    }
+
+    public State Execute(State state)
+    {
+        var clone = state.Clone();
+        var originalVariables = GetNonNullableVariables(state);
+
+        foreach (var kvp in _transformations)
+        {
+            var value = _evaluator.Evaluate(kvp.Value, originalVariables);
+            clone.Variables[kvp.Key] = value;
+        }
+
+        return clone;
+    }
+
+    public string GetName() => _name;
+
+    private static Dictionary<string, object> GetNonNullableVariables(State state)
+    {
+        var dict = new Dictionary<string, object>();
+        foreach (var kvp in state.Variables)
+        {
+            if (kvp.Value is not null)
+                dict[kvp.Key] = kvp.Value;
+        }
+        return dict;
+    }
+}

--- a/src/StateMaker/RuleBuilder.cs
+++ b/src/StateMaker/RuleBuilder.cs
@@ -1,0 +1,23 @@
+namespace StateMaker;
+
+public static class RuleBuilder
+{
+    private static readonly ExpressionEvaluator DefaultEvaluator = new();
+
+    public static DeclarativeRule DefineRule(
+        string name,
+        string condition,
+        Dictionary<string, string> transformations)
+    {
+        return new DeclarativeRule(name, condition, transformations, DefaultEvaluator);
+    }
+
+    public static DeclarativeRule DefineRule(
+        string name,
+        string condition,
+        Dictionary<string, string> transformations,
+        IExpressionEvaluator evaluator)
+    {
+        return new DeclarativeRule(name, condition, transformations, evaluator);
+    }
+}

--- a/src/StateMaker/RuleFileLoader.cs
+++ b/src/StateMaker/RuleFileLoader.cs
@@ -1,0 +1,177 @@
+using System.Reflection;
+using System.Text.Json;
+
+namespace StateMaker;
+
+public class RuleFileLoader
+{
+    private readonly IExpressionEvaluator _evaluator;
+
+    public RuleFileLoader(IExpressionEvaluator evaluator)
+    {
+        ArgumentNullException.ThrowIfNull(evaluator);
+        _evaluator = evaluator;
+    }
+
+    public (State? initialState, IRule[] rules) LoadFromFile(string filePath)
+    {
+        if (!File.Exists(filePath))
+            throw new FileNotFoundException($"Rule file not found: {filePath}", filePath);
+
+        var json = File.ReadAllText(filePath);
+        return LoadFromJson(json);
+    }
+
+    public (State? initialState, IRule[] rules) LoadFromJson(string json)
+    {
+        ArgumentNullException.ThrowIfNull(json);
+
+        JsonDocument doc;
+        try
+        {
+            doc = JsonDocument.Parse(json);
+        }
+        catch (JsonException ex)
+        {
+            throw new InvalidOperationException($"Invalid JSON syntax: {ex.Message}", ex);
+        }
+
+        var root = doc.RootElement;
+
+        var initialState = ParseInitialState(root);
+        var rules = ParseRules(root);
+
+        return (initialState, rules);
+    }
+
+    private static State? ParseInitialState(JsonElement root)
+    {
+        if (!root.TryGetProperty("initialState", out var stateElement))
+            return null;
+
+        if (stateElement.ValueKind == JsonValueKind.Null)
+            return null;
+
+        var state = new State();
+        foreach (var prop in stateElement.EnumerateObject())
+        {
+            state.Variables[prop.Name] = ConvertJsonValue(prop.Value);
+        }
+        return state;
+    }
+
+    private IRule[] ParseRules(JsonElement root)
+    {
+        if (!root.TryGetProperty("rules", out var rulesElement))
+            throw new InvalidOperationException("JSON must contain a 'rules' array.");
+
+        var rules = new List<IRule>();
+        foreach (var ruleElement in rulesElement.EnumerateArray())
+        {
+            rules.Add(ParseSingleRule(ruleElement));
+        }
+        return rules.ToArray();
+    }
+
+    private IRule ParseSingleRule(JsonElement element)
+    {
+        var type = GetOptionalString(element, "type");
+
+        if (type == null || type.Equals("declarative", StringComparison.OrdinalIgnoreCase))
+            return ParseDeclarativeRule(element);
+
+        if (type.Equals("custom", StringComparison.OrdinalIgnoreCase))
+            return ParseCustomRule(element);
+
+        throw new InvalidOperationException(
+            $"Unknown rule type '{type}'. Supported types: 'declarative', 'custom'.");
+    }
+
+    private DeclarativeRule ParseDeclarativeRule(JsonElement element)
+    {
+        var name = GetOptionalString(element, "name")
+            ?? throw new InvalidOperationException(
+                "Declarative rule is missing required 'name' field.");
+
+        var condition = GetOptionalString(element, "condition")
+            ?? throw new InvalidOperationException(
+                $"Declarative rule '{name}' is missing required 'condition' field.");
+
+        var transformations = new Dictionary<string, string>();
+        if (element.TryGetProperty("transformations", out var transElement))
+        {
+            foreach (var prop in transElement.EnumerateObject())
+            {
+                transformations[prop.Name] = prop.Value.GetString()
+                    ?? throw new InvalidOperationException(
+                        $"Transformation value for '{prop.Name}' in rule '{name}' must be a string expression.");
+            }
+        }
+
+        return new DeclarativeRule(name, condition, transformations, _evaluator);
+    }
+
+    private static IRule ParseCustomRule(JsonElement element)
+    {
+        var assemblyPath = GetOptionalString(element, "assemblyPath")
+            ?? throw new InvalidOperationException(
+                "Custom rule is missing required 'assemblyPath' field.");
+
+        var className = GetOptionalString(element, "className")
+            ?? throw new InvalidOperationException(
+                "Custom rule is missing required 'className' field.");
+
+        Assembly assembly;
+        try
+        {
+            assembly = Assembly.LoadFrom(assemblyPath);
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException(
+                $"Failed to load assembly '{assemblyPath}': {ex.Message}", ex);
+        }
+
+        var type = assembly.GetType(className)
+            ?? throw new InvalidOperationException(
+                $"Class '{className}' not found in assembly '{assemblyPath}'.");
+
+        if (!typeof(IRule).IsAssignableFrom(type))
+            throw new InvalidOperationException(
+                $"Class '{className}' does not implement IRule.");
+
+        var constructor = type.GetConstructor(Type.EmptyTypes);
+        if (constructor == null)
+            throw new InvalidOperationException(
+                $"Class '{className}' does not have a parameterless constructor.");
+
+        try
+        {
+            return (IRule)constructor.Invoke(null);
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException(
+                $"Failed to instantiate class '{className}': {ex.Message}", ex);
+        }
+    }
+
+    private static object? ConvertJsonValue(JsonElement element)
+    {
+        return element.ValueKind switch
+        {
+            JsonValueKind.String => element.GetString(),
+            JsonValueKind.True => true,
+            JsonValueKind.False => false,
+            JsonValueKind.Number when element.TryGetInt32(out var i) => i,
+            JsonValueKind.Number => element.GetDouble(),
+            JsonValueKind.Null => null,
+            _ => element.GetRawText()
+        };
+    }
+
+    private static string? GetOptionalString(JsonElement element, string propertyName)
+    {
+        return element.TryGetProperty(propertyName, out var prop) ? prop.GetString() : null;
+    }
+}

--- a/tasks/prd-declarative-rules-json-loader.md
+++ b/tasks/prd-declarative-rules-json-loader.md
@@ -1,0 +1,99 @@
+# PRD: Task 6.0 — Declarative Rules and JSON File Loader
+
+## Overview
+
+Implement a `DeclarativeRule` class that implements `IRule` using expression strings evaluated by `IExpressionEvaluator`, and a `RuleFileLoader` that reads JSON files to produce initial state and rule arrays. Also provide a programmatic `RuleBuilder` API for creating declarative rules without files.
+
+## Dependencies
+
+- Task 5.0 (Expression Evaluation System) — completed
+- `IExpressionEvaluator` / `ExpressionEvaluator` using NCalcSync v5.11.0
+- `IRule` interface with `IsAvailable`, `Execute`, `GetName`
+- `State` class with `Dictionary<string, object?>` Variables and `Clone()`
+
+## Sub-tasks
+
+### 6.1 — DeclarativeRule class
+- Implements `IRule`
+- Constructor: `(string name, string condition, Dictionary<string, string> transformations, IExpressionEvaluator evaluator)`
+- Stores name, condition expression string, transformations (variable name → expression string)
+- Overrides `GetName()` to return the configured name
+
+### 6.2 — DeclarativeRule.IsAvailable()
+- Casts `State.Variables` to `Dictionary<string, object>` (stripping nullable)
+- Calls `evaluator.EvaluateBoolean(condition, variables)`
+- Returns result
+
+### 6.3 — DeclarativeRule.Execute()
+- Clones the input state
+- Evaluates each transformation expression against the **original** state's variables (not the clone's)
+- Sets the evaluated results on the clone's variables
+- Returns the clone
+
+### 6.4 — DeclarativeRule unit tests
+- Condition true/false
+- Single and multiple transformations
+- Transformations evaluated against original state (not intermediate)
+- Input state immutability
+- GetName() returns configured name
+- Error cases: invalid condition, invalid transformation expression
+
+### 6.5–6.7 — RuleFileLoader (JSON parsing)
+- `RuleFileLoader` class with method: `(State? initialState, IRule[] rules) LoadFromFile(string filePath)`
+- Also: `(State? initialState, IRule[] rules) LoadFromJson(string json)` for testability
+- JSON schema:
+  ```json
+  {
+    "initialState": { "Status": "Pending", "Count": 0 },
+    "rules": [
+      {
+        "name": "ApproveRule",
+        "condition": "[Status] == 'Pending'",
+        "transformations": { "Status": "'Approved'" }
+      },
+      {
+        "type": "custom",
+        "assemblyPath": "path/to/assembly.dll",
+        "className": "MyNamespace.MyRule"
+      }
+    ]
+  }
+  ```
+- `initialState` is optional — returns null if absent
+- Rules without `type` or with `type: "declarative"` → `DeclarativeRule`
+- Uses `System.Text.Json` (built-in, no extra dependency)
+
+### 6.8 — Custom rule loading via reflection
+- `type: "custom"` rules specify `assemblyPath` and `className`
+- Load assembly via `Assembly.LoadFrom()`
+- Find type, verify it implements `IRule`
+- Instantiate via parameterless constructor using `Activator.CreateInstance()`
+
+### 6.9 — Validation and error messages
+- Missing `name` for declarative rules
+- Missing `condition` for declarative rules
+- Invalid JSON syntax
+- `className` not found in assembly
+- Class doesn't implement `IRule`
+- No parameterless constructor
+- File not found
+
+### 6.10 — RuleFileLoader tests
+- Valid declarative rules
+- Valid custom rules (using a test assembly rule)
+- Mixed declarative + custom rules
+- Missing initialState (returns null)
+- Present initialState with various types
+- All error cases from 6.9
+
+### 6.11–6.12 — Programmatic RuleBuilder API
+- Static `RuleBuilder` class with fluent or simple factory method
+- `RuleBuilder.DefineRule(string name, string condition, Dictionary<string, string> transformations)` → `DeclarativeRule`
+- Unit tests for the programmatic API
+
+## Design Decisions
+
+- Use `System.Text.Json` (no extra NuGet dependency needed for .NET 6.0)
+- `RuleFileLoader` takes `IExpressionEvaluator` in constructor (dependency injection)
+- Transformations evaluated against **original** state variables to avoid order-dependent behavior
+- `DeclarativeRule` is a public, non-sealed class in the `StateMaker` namespace

--- a/tasks/tasks-state-machine-builder.md
+++ b/tasks/tasks-state-machine-builder.md
@@ -212,19 +212,19 @@ All tests must pass before moving on to the next sub-task.
   - [x] 5.9 Ensure expressions are sandboxed (no file system, network, reflection, or arbitrary code execution)
   - [x] 5.10 Write unit tests for each operator type, variable resolution with all primitive types, compound expressions, and all error cases
 
-- [ ] 6.0 Implement declarative rules and JSON file loader
-  - [ ] 6.1 Implement `DeclarativeRule` class that implements `IRule`, storing name, condition string, and transformations dictionary
-  - [ ] 6.2 Implement `DeclarativeRule.IsAvailable()` — evaluates condition expression against state variables using `IExpressionEvaluator.EvaluateBoolean()`
-  - [ ] 6.3 Implement `DeclarativeRule.Execute()` — clones state, evaluates each transformation expression against the **original** state variables, sets new values on the clone
-  - [ ] 6.4 Write unit tests for DeclarativeRule: condition evaluation, transformation application, immutability of input state, multiple transformations
-  - [ ] 6.5 Implement `RuleFileLoader` class that reads a JSON file and returns initial state (if present) and an `IRule[]` array
-  - [ ] 6.6 Implement JSON parsing for `initialState` object — construct a `State` from the key-value pairs
-  - [ ] 6.7 Implement JSON parsing for declarative rule entries (rules without `type` or with `type: "declarative"`) — create `DeclarativeRule` instances
-  - [ ] 6.8 Implement JSON parsing for custom rule entries (`type: "custom"`) — load assembly, instantiate class via reflection, validate it implements `IRule`
-  - [ ] 6.9 Implement validation and clear error messages: missing required fields, invalid JSON syntax, class not found, class doesn't implement IRule, no parameterless constructor
-  - [ ] 6.10 Write unit tests for file loader: valid declarative rules, valid custom rules, mixed rules, missing initialState, present initialState, all error cases
-  - [ ] 6.11 Provide a programmatic API method to create declarative rules without a file (e.g., `RuleBuilder.DefineRule(name, condition, transformations)`)
-  - [ ] 6.12 Write unit tests for programmatic declarative rule creation
+- [x] 6.0 Implement declarative rules and JSON file loader
+  - [x] 6.1 Implement `DeclarativeRule` class that implements `IRule`, storing name, condition string, and transformations dictionary
+  - [x] 6.2 Implement `DeclarativeRule.IsAvailable()` — evaluates condition expression against state variables using `IExpressionEvaluator.EvaluateBoolean()`
+  - [x] 6.3 Implement `DeclarativeRule.Execute()` — clones state, evaluates each transformation expression against the **original** state variables, sets new values on the clone
+  - [x] 6.4 Write unit tests for DeclarativeRule: condition evaluation, transformation application, immutability of input state, multiple transformations
+  - [x] 6.5 Implement `RuleFileLoader` class that reads a JSON file and returns initial state (if present) and an `IRule[]` array
+  - [x] 6.6 Implement JSON parsing for `initialState` object — construct a `State` from the key-value pairs
+  - [x] 6.7 Implement JSON parsing for declarative rule entries (rules without `type` or with `type: "declarative"`) — create `DeclarativeRule` instances
+  - [x] 6.8 Implement JSON parsing for custom rule entries (`type: "custom"`) — load assembly, instantiate class via reflection, validate it implements `IRule`
+  - [x] 6.9 Implement validation and clear error messages: missing required fields, invalid JSON syntax, class not found, class doesn't implement IRule, no parameterless constructor
+  - [x] 6.10 Write unit tests for file loader: valid declarative rules, valid custom rules, mixed rules, missing initialState, present initialState, all error cases
+  - [x] 6.11 Provide a programmatic API method to create declarative rules without a file (e.g., `RuleBuilder.DefineRule(name, condition, transformations)`)
+  - [x] 6.12 Write unit tests for programmatic declarative rule creation
 
 - [ ] 7.0 Implement export and import capabilities (JSON, DOT, GraphML)
   - [ ] 7.1 Define `IStateMachineExporter` interface with `string Export(StateMachine stateMachine)` method


### PR DESCRIPTION
## Summary
- Implement `DeclarativeRule` class that implements `IRule` using expression strings evaluated by `IExpressionEvaluator`, with condition-based availability and transformation-based execution against original state
- Implement `RuleFileLoader` for parsing JSON files into initial state and rule arrays, supporting both declarative and custom (reflection-based) rule types with validation
- Implement `RuleBuilder` static factory for programmatic declarative rule creation without files
- 56 new tests (580 total), all passing

## Test plan
- [x] DeclarativeRule: condition evaluation, transformations, immutability, error cases, builder integration
- [x] RuleFileLoader: JSON parsing, initial state, declarative/custom/mixed rules, file loading, all validation errors
- [x] RuleBuilder: programmatic API, builder integration, multiple rules working together
- [x] All 580 tests pass

Generated with [Claude Code](https://claude.com/claude-code)