### PR TITLE
Add StateMaker.Console project scaffolding (task 1.0)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,5 +4,6 @@
     <AnalysisLevel>latest-recommended</AnalysisLevel>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <CheckEolTargetFramework>false</CheckEolTargetFramework>
   </PropertyGroup>
 </Project>

--- a/StateMaker.sln
+++ b/StateMaker.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StateMaker", "src\StateMake
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StateMaker.Tests", "src\StateMaker.Tests\StateMaker.Tests.csproj", "{7A3B6267-BE18-4F48-A9C4-E9ED7CE9FAEB}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StateMaker.Console", "src\StateMaker.Console\StateMaker.Console.csproj", "{0D9843C7-A61D-4142-AFFA-770CDD4873BA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -43,6 +45,18 @@ Global
 		{7A3B6267-BE18-4F48-A9C4-E9ED7CE9FAEB}.Release|x64.Build.0 = Release|Any CPU
 		{7A3B6267-BE18-4F48-A9C4-E9ED7CE9FAEB}.Release|x86.ActiveCfg = Release|Any CPU
 		{7A3B6267-BE18-4F48-A9C4-E9ED7CE9FAEB}.Release|x86.Build.0 = Release|Any CPU
+		{0D9843C7-A61D-4142-AFFA-770CDD4873BA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0D9843C7-A61D-4142-AFFA-770CDD4873BA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0D9843C7-A61D-4142-AFFA-770CDD4873BA}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{0D9843C7-A61D-4142-AFFA-770CDD4873BA}.Debug|x64.Build.0 = Debug|Any CPU
+		{0D9843C7-A61D-4142-AFFA-770CDD4873BA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{0D9843C7-A61D-4142-AFFA-770CDD4873BA}.Debug|x86.Build.0 = Debug|Any CPU
+		{0D9843C7-A61D-4142-AFFA-770CDD4873BA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0D9843C7-A61D-4142-AFFA-770CDD4873BA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0D9843C7-A61D-4142-AFFA-770CDD4873BA}.Release|x64.ActiveCfg = Release|Any CPU
+		{0D9843C7-A61D-4142-AFFA-770CDD4873BA}.Release|x64.Build.0 = Release|Any CPU
+		{0D9843C7-A61D-4142-AFFA-770CDD4873BA}.Release|x86.ActiveCfg = Release|Any CPU
+		{0D9843C7-A61D-4142-AFFA-770CDD4873BA}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -50,5 +64,6 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{02FC89F9-6395-48BD-8683-650064E39A48} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{7A3B6267-BE18-4F48-A9C4-E9ED7CE9FAEB} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{0D9843C7-A61D-4142-AFFA-770CDD4873BA} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 EndGlobal

--- a/src/StateMaker.Console/Program.cs
+++ b/src/StateMaker.Console/Program.cs
@@ -1,0 +1,9 @@
+namespace StateMaker.Console;
+
+public class Program
+{
+    public static int Main(string[] args)
+    {
+        return 0;
+    }
+}

--- a/src/StateMaker.Console/StateMaker.Console.csproj
+++ b/src/StateMaker.Console/StateMaker.Console.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\StateMaker\StateMaker.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tasks/tasks-console-application.md
+++ b/tasks/tasks-console-application.md
@@ -45,11 +45,11 @@ All tests must pass before moving on to the next sub-task.
 
 - [x] 0.0 Create feature branch
   - [x] 0.1 Create and checkout a new branch for this feature (e.g., `git checkout -b consoleapp`)
-- [ ] 1.0 Set up the console application project
-  - [ ] 1.1 Create new console project directory `src/StateMaker.Console`
-  - [ ] 1.2 Create `StateMaker.Console.csproj` targeting `net6.0` as an executable, referencing the `StateMaker` library project
-  - [ ] 1.3 Add the new project to `StateMaker.sln`
-  - [ ] 1.4 Verify the solution builds successfully with `dotnet build`
+- [x] 1.0 Set up the console application project
+  - [x] 1.1 Create new console project directory `src/StateMaker.Console`
+  - [x] 1.2 Create `StateMaker.Console.csproj` targeting `net6.0` as an executable, referencing the `StateMaker` library project
+  - [x] 1.3 Add the new project to `StateMaker.sln`
+  - [x] 1.4 Verify the solution builds successfully with `dotnet build`
 - [ ] 2.0 Implement the build definition file parser
   - [ ] 2.1 Create `BuildDefinitionLoader.cs` that parses a combined JSON file containing `initialState`, `rules`, and optional `config` sections
   - [ ] 2.2 Parse the `initialState` section into a `State` object (reuse `RuleFileLoader` logic or call its methods)


### PR DESCRIPTION
## Summary
- Create new console application project (StateMaker.Console) targeting net6.0
- Add project reference to StateMaker library
- Add project to solution file
- Minimal Program.cs stub in place for future command routing

## Test plan
- [x] Solution builds successfully (all 3 projects)
- [x] All 648 existing tests pass with no regressions

Generated with Claude Code