### PR TITLE
Add BuildDefinitionLoader and shared JSON property constants (task 2.0)

### DIFF
--- a/src/StateMaker.Tests/BuildDefinitionLoaderTests.cs
+++ b/src/StateMaker.Tests/BuildDefinitionLoaderTests.cs
@@ -1,0 +1,372 @@
+using Xunit;
+
+namespace StateMaker.Tests;
+
+public class BuildDefinitionLoaderTests
+{
+    #region Null and Invalid Input
+
+    [Fact]
+    public void LoadFromJson_NullInput_ThrowsArgumentNullException()
+    {
+        var loader = new BuildDefinitionLoader();
+
+        Assert.Throws<ArgumentNullException>(() => loader.LoadFromJson(null!));
+    }
+
+    [Fact]
+    public void LoadFromJson_InvalidJson_ThrowsInvalidOperationException()
+    {
+        var loader = new BuildDefinitionLoader();
+
+        Assert.Throws<InvalidOperationException>(() => loader.LoadFromJson("not valid json"));
+    }
+
+    [Fact]
+    public void LoadFromJson_MissingInitialState_ThrowsInvalidOperationException()
+    {
+        var loader = new BuildDefinitionLoader();
+        var json = @"{ ""rules"": [] }";
+
+        var ex = Assert.Throws<InvalidOperationException>(() => loader.LoadFromJson(json));
+        Assert.Contains("initialState", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void LoadFromJson_MissingRules_ThrowsInvalidOperationException()
+    {
+        var loader = new BuildDefinitionLoader();
+        var json = @"{ ""initialState"": { ""x"": 1 } }";
+
+        var ex = Assert.Throws<InvalidOperationException>(() => loader.LoadFromJson(json));
+        Assert.Contains("rules", ex.Message, StringComparison.Ordinal);
+    }
+
+    #endregion
+
+    #region InitialState Parsing
+
+    [Fact]
+    public void LoadFromJson_InitialStateWithIntVariable_ParsesCorrectly()
+    {
+        var loader = new BuildDefinitionLoader();
+        var json = @"{ ""initialState"": { ""x"": 1 }, ""rules"": [] }";
+
+        var result = loader.LoadFromJson(json);
+
+        Assert.Equal(1, result.InitialState.Variables["x"]);
+    }
+
+    [Fact]
+    public void LoadFromJson_InitialStateWithStringVariable_ParsesCorrectly()
+    {
+        var loader = new BuildDefinitionLoader();
+        var json = @"{ ""initialState"": { ""name"": ""hello"" }, ""rules"": [] }";
+
+        var result = loader.LoadFromJson(json);
+
+        Assert.Equal("hello", result.InitialState.Variables["name"]);
+    }
+
+    [Fact]
+    public void LoadFromJson_InitialStateWithBoolVariable_ParsesCorrectly()
+    {
+        var loader = new BuildDefinitionLoader();
+        var json = @"{ ""initialState"": { ""flag"": true }, ""rules"": [] }";
+
+        var result = loader.LoadFromJson(json);
+
+        Assert.Equal(true, result.InitialState.Variables["flag"]);
+    }
+
+    [Fact]
+    public void LoadFromJson_InitialStateWithMultipleVariables_ParsesAll()
+    {
+        var loader = new BuildDefinitionLoader();
+        var json = @"{ ""initialState"": { ""x"": 1, ""y"": 2, ""z"": 3 }, ""rules"": [] }";
+
+        var result = loader.LoadFromJson(json);
+
+        Assert.Equal(3, result.InitialState.Variables.Count);
+        Assert.Equal(1, result.InitialState.Variables["x"]);
+        Assert.Equal(2, result.InitialState.Variables["y"]);
+        Assert.Equal(3, result.InitialState.Variables["z"]);
+    }
+
+    #endregion
+
+    #region Rules Parsing
+
+    [Fact]
+    public void LoadFromJson_EmptyRulesArray_ReturnsEmptyRules()
+    {
+        var loader = new BuildDefinitionLoader();
+        var json = @"{ ""initialState"": { ""x"": 1 }, ""rules"": [] }";
+
+        var result = loader.LoadFromJson(json);
+
+        Assert.Empty(result.Rules);
+    }
+
+    [Fact]
+    public void LoadFromJson_SingleDeclarativeRule_ParsesCorrectly()
+    {
+        var loader = new BuildDefinitionLoader();
+        var json = @"{
+            ""initialState"": { ""x"": 0 },
+            ""rules"": [
+                {
+                    ""name"": ""IncrementX"",
+                    ""condition"": ""x < 5"",
+                    ""transformations"": { ""x"": ""x + 1"" }
+                }
+            ]
+        }";
+
+        var result = loader.LoadFromJson(json);
+
+        Assert.Single(result.Rules);
+        Assert.Equal("IncrementX", result.Rules[0].GetName());
+    }
+
+    [Fact]
+    public void LoadFromJson_MultipleRules_ParsesAll()
+    {
+        var loader = new BuildDefinitionLoader();
+        var json = @"{
+            ""initialState"": { ""x"": 0 },
+            ""rules"": [
+                {
+                    ""name"": ""RuleA"",
+                    ""condition"": ""x < 5"",
+                    ""transformations"": { ""x"": ""x + 1"" }
+                },
+                {
+                    ""name"": ""RuleB"",
+                    ""condition"": ""x > 0"",
+                    ""transformations"": { ""x"": ""x - 1"" }
+                }
+            ]
+        }";
+
+        var result = loader.LoadFromJson(json);
+
+        Assert.Equal(2, result.Rules.Length);
+    }
+
+    #endregion
+
+    #region Config Parsing
+
+    [Fact]
+    public void LoadFromJson_NoConfig_ReturnsDefaults()
+    {
+        var loader = new BuildDefinitionLoader();
+        var json = @"{ ""initialState"": { ""x"": 1 }, ""rules"": [] }";
+
+        var result = loader.LoadFromJson(json);
+
+        Assert.Null(result.Config.MaxStates);
+        Assert.Null(result.Config.MaxDepth);
+        Assert.Equal(ExplorationStrategy.BREADTHFIRSTSEARCH, result.Config.ExplorationStrategy);
+    }
+
+    [Fact]
+    public void LoadFromJson_ConfigWithMaxStates_ParsesCorrectly()
+    {
+        var loader = new BuildDefinitionLoader();
+        var json = @"{
+            ""initialState"": { ""x"": 1 },
+            ""rules"": [],
+            ""config"": { ""maxStates"": 50 }
+        }";
+
+        var result = loader.LoadFromJson(json);
+
+        Assert.Equal(50, result.Config.MaxStates);
+    }
+
+    [Fact]
+    public void LoadFromJson_ConfigWithMaxDepth_ParsesCorrectly()
+    {
+        var loader = new BuildDefinitionLoader();
+        var json = @"{
+            ""initialState"": { ""x"": 1 },
+            ""rules"": [],
+            ""config"": { ""maxDepth"": 10 }
+        }";
+
+        var result = loader.LoadFromJson(json);
+
+        Assert.Equal(10, result.Config.MaxDepth);
+    }
+
+    [Fact]
+    public void LoadFromJson_ConfigWithBreadthFirstSearch_ParsesCorrectly()
+    {
+        var loader = new BuildDefinitionLoader();
+        var json = @"{
+            ""initialState"": { ""x"": 1 },
+            ""rules"": [],
+            ""config"": { ""explorationStrategy"": ""BreadthFirstSearch"" }
+        }";
+
+        var result = loader.LoadFromJson(json);
+
+        Assert.Equal(ExplorationStrategy.BREADTHFIRSTSEARCH, result.Config.ExplorationStrategy);
+    }
+
+    [Fact]
+    public void LoadFromJson_ConfigWithDepthFirstSearch_ParsesCorrectly()
+    {
+        var loader = new BuildDefinitionLoader();
+        var json = @"{
+            ""initialState"": { ""x"": 1 },
+            ""rules"": [],
+            ""config"": { ""explorationStrategy"": ""DepthFirstSearch"" }
+        }";
+
+        var result = loader.LoadFromJson(json);
+
+        Assert.Equal(ExplorationStrategy.DEPTHFIRSTSEARCH, result.Config.ExplorationStrategy);
+    }
+
+    [Fact]
+    public void LoadFromJson_ConfigWithAllFields_ParsesAll()
+    {
+        var loader = new BuildDefinitionLoader();
+        var json = @"{
+            ""initialState"": { ""x"": 1 },
+            ""rules"": [],
+            ""config"": { ""maxStates"": 100, ""maxDepth"": 20, ""explorationStrategy"": ""DepthFirstSearch"" }
+        }";
+
+        var result = loader.LoadFromJson(json);
+
+        Assert.Equal(100, result.Config.MaxStates);
+        Assert.Equal(20, result.Config.MaxDepth);
+        Assert.Equal(ExplorationStrategy.DEPTHFIRSTSEARCH, result.Config.ExplorationStrategy);
+    }
+
+    [Fact]
+    public void LoadFromJson_ConfigWithInvalidStrategy_ThrowsInvalidOperationException()
+    {
+        var loader = new BuildDefinitionLoader();
+        var json = @"{
+            ""initialState"": { ""x"": 1 },
+            ""rules"": [],
+            ""config"": { ""explorationStrategy"": ""RandomSearch"" }
+        }";
+
+        var ex = Assert.Throws<InvalidOperationException>(() => loader.LoadFromJson(json));
+        Assert.Contains("RandomSearch", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void LoadFromJson_EmptyConfig_ReturnsDefaults()
+    {
+        var loader = new BuildDefinitionLoader();
+        var json = @"{
+            ""initialState"": { ""x"": 1 },
+            ""rules"": [],
+            ""config"": {}
+        }";
+
+        var result = loader.LoadFromJson(json);
+
+        Assert.Null(result.Config.MaxStates);
+        Assert.Null(result.Config.MaxDepth);
+        Assert.Equal(ExplorationStrategy.BREADTHFIRSTSEARCH, result.Config.ExplorationStrategy);
+    }
+
+    #endregion
+
+    #region Integration — Full Build Definition
+
+    [Fact]
+    public void LoadFromJson_FullDefinition_AllSectionsParsed()
+    {
+        var loader = new BuildDefinitionLoader();
+        var json = @"{
+            ""initialState"": { ""counter"": 0 },
+            ""rules"": [
+                {
+                    ""name"": ""Increment"",
+                    ""condition"": ""counter < 3"",
+                    ""transformations"": { ""counter"": ""counter + 1"" }
+                }
+            ],
+            ""config"": { ""maxStates"": 10, ""maxDepth"": 5 }
+        }";
+
+        var result = loader.LoadFromJson(json);
+
+        Assert.Equal(0, result.InitialState.Variables["counter"]);
+        Assert.Single(result.Rules);
+        Assert.Equal("Increment", result.Rules[0].GetName());
+        Assert.Equal(10, result.Config.MaxStates);
+        Assert.Equal(5, result.Config.MaxDepth);
+    }
+
+    [Fact]
+    public void LoadFromJson_RulesCanExecuteAgainstInitialState()
+    {
+        var loader = new BuildDefinitionLoader();
+        var json = @"{
+            ""initialState"": { ""x"": 0 },
+            ""rules"": [
+                {
+                    ""name"": ""Inc"",
+                    ""condition"": ""x < 2"",
+                    ""transformations"": { ""x"": ""x + 1"" }
+                }
+            ]
+        }";
+
+        var result = loader.LoadFromJson(json);
+
+        Assert.True(result.Rules[0].IsAvailable(result.InitialState));
+        var newState = result.Rules[0].Execute(result.InitialState);
+        Assert.Equal(1, newState.Variables["x"]);
+    }
+
+    [Fact]
+    public void LoadFromJson_CanBuildStateMachineFromResult()
+    {
+        var loader = new BuildDefinitionLoader();
+        var json = @"{
+            ""initialState"": { ""step"": 0 },
+            ""rules"": [
+                {
+                    ""name"": ""Step"",
+                    ""condition"": ""step < 3"",
+                    ""transformations"": { ""step"": ""step + 1"" }
+                }
+            ],
+            ""config"": { ""maxStates"": 10 }
+        }";
+
+        var result = loader.LoadFromJson(json);
+        var builder = new StateMachineBuilder();
+        var stateMachine = builder.Build(result.InitialState, result.Rules, result.Config);
+
+        Assert.Equal(4, stateMachine.States.Count);
+        Assert.Equal(3, stateMachine.Transitions.Count);
+        Assert.True(stateMachine.IsValidMachine());
+    }
+
+    #endregion
+
+    #region LoadFromFile
+
+    [Fact]
+    public void LoadFromFile_FileNotFound_ThrowsFileNotFoundException()
+    {
+        var loader = new BuildDefinitionLoader();
+
+        Assert.Throws<FileNotFoundException>(() =>
+            loader.LoadFromFile("nonexistent-file.json"));
+    }
+
+    #endregion
+}

--- a/src/StateMaker/BuildDefinitionLoader.cs
+++ b/src/StateMaker/BuildDefinitionLoader.cs
@@ -1,0 +1,86 @@
+using System.Text.Json;
+
+namespace StateMaker;
+
+public class BuildDefinitionResult
+{
+    public State InitialState { get; set; } = new();
+    public IRule[] Rules { get; set; } = Array.Empty<IRule>();
+    public BuilderConfig Config { get; set; } = new();
+}
+
+public class BuildDefinitionLoader
+{
+    private readonly RuleFileLoader _ruleFileLoader = new(new ExpressionEvaluator());
+
+    public BuildDefinitionResult LoadFromJson(string json)
+    {
+        ArgumentNullException.ThrowIfNull(json);
+
+        JsonDocument doc;
+        try
+        {
+            doc = JsonDocument.Parse(json);
+        }
+        catch (JsonException ex)
+        {
+            throw new InvalidOperationException($"Invalid JSON syntax: {ex.Message}", ex);
+        }
+
+        var root = doc.RootElement;
+
+        var (initialState, rules) = _ruleFileLoader.LoadFromJson(json);
+
+        if (initialState is null)
+            throw new InvalidOperationException($"Build definition must contain an '{BuildJsonPropertyNames.InitialState}' object.");
+
+        if (!root.TryGetProperty(BuildJsonPropertyNames.Rules, out _))
+            throw new InvalidOperationException($"Build definition must contain a '{BuildJsonPropertyNames.Rules}' array.");
+
+        var config = ParseConfig(root);
+
+        return new BuildDefinitionResult
+        {
+            InitialState = initialState,
+            Rules = rules,
+            Config = config
+        };
+    }
+
+    public BuildDefinitionResult LoadFromFile(string filePath)
+    {
+        if (!File.Exists(filePath))
+            throw new FileNotFoundException($"Build definition file not found: {filePath}", filePath);
+
+        var json = File.ReadAllText(filePath);
+        return LoadFromJson(json);
+    }
+
+    private static BuilderConfig ParseConfig(JsonElement root)
+    {
+        var config = new BuilderConfig();
+
+        if (!root.TryGetProperty(BuildJsonPropertyNames.Config, out var configElement))
+            return config;
+
+        if (configElement.TryGetProperty(BuildJsonPropertyNames.MaxStates, out var maxStatesElement))
+            config.MaxStates = maxStatesElement.GetInt32();
+
+        if (configElement.TryGetProperty(BuildJsonPropertyNames.MaxDepth, out var maxDepthElement))
+            config.MaxDepth = maxDepthElement.GetInt32();
+
+        if (configElement.TryGetProperty(BuildJsonPropertyNames.ExplorationStrategy, out var strategyElement))
+        {
+            var strategyString = strategyElement.GetString();
+            config.ExplorationStrategy = strategyString switch
+            {
+                BuildJsonPropertyNames.BreadthFirstSearch => StateMaker.ExplorationStrategy.BREADTHFIRSTSEARCH,
+                BuildJsonPropertyNames.DepthFirstSearch => StateMaker.ExplorationStrategy.DEPTHFIRSTSEARCH,
+                _ => throw new InvalidOperationException(
+                    $"Unknown exploration strategy '{strategyString}'. Supported values: '{BuildJsonPropertyNames.BreadthFirstSearch}', '{BuildJsonPropertyNames.DepthFirstSearch}'.")
+            };
+        }
+
+        return config;
+    }
+}

--- a/src/StateMaker/BuildJsonPropertyNames.cs
+++ b/src/StateMaker/BuildJsonPropertyNames.cs
@@ -1,0 +1,30 @@
+namespace StateMaker;
+
+internal static class BuildJsonPropertyNames
+{
+    // Build definition sections
+    public const string InitialState = "initialState";
+    public const string Rules = "rules";
+    public const string Config = "config";
+
+    // Rule properties
+    public const string Type = "type";
+    public const string Name = "name";
+    public const string Condition = "condition";
+    public const string Transformations = "transformations";
+    public const string AssemblyPath = "assemblyPath";
+    public const string ClassName = "className";
+
+    // Rule type values
+    public const string Declarative = "declarative";
+    public const string Custom = "custom";
+
+    // Config properties
+    public const string MaxStates = "maxStates";
+    public const string MaxDepth = "maxDepth";
+    public const string ExplorationStrategy = "explorationStrategy";
+
+    // Exploration strategy values
+    public const string BreadthFirstSearch = "BreadthFirstSearch";
+    public const string DepthFirstSearch = "DepthFirstSearch";
+}

--- a/src/StateMaker/RuleFileLoader.cs
+++ b/src/StateMaker/RuleFileLoader.cs
@@ -46,7 +46,7 @@ public class RuleFileLoader
 
     private static State? ParseInitialState(JsonElement root)
     {
-        if (!root.TryGetProperty("initialState", out var stateElement))
+        if (!root.TryGetProperty(BuildJsonPropertyNames.InitialState, out var stateElement))
             return null;
 
         if (stateElement.ValueKind == JsonValueKind.Null)
@@ -62,8 +62,8 @@ public class RuleFileLoader
 
     private IRule[] ParseRules(JsonElement root)
     {
-        if (!root.TryGetProperty("rules", out var rulesElement))
-            throw new InvalidOperationException("JSON must contain a 'rules' array.");
+        if (!root.TryGetProperty(BuildJsonPropertyNames.Rules, out var rulesElement))
+            throw new InvalidOperationException($"JSON must contain a '{BuildJsonPropertyNames.Rules}' array.");
 
         var rules = new List<IRule>();
         foreach (var ruleElement in rulesElement.EnumerateArray())
@@ -75,30 +75,30 @@ public class RuleFileLoader
 
     private IRule ParseSingleRule(JsonElement element)
     {
-        var type = GetOptionalString(element, "type");
+        var type = GetOptionalString(element, BuildJsonPropertyNames.Type);
 
-        if (type == null || type.Equals("declarative", StringComparison.OrdinalIgnoreCase))
+        if (type == null || type.Equals(BuildJsonPropertyNames.Declarative, StringComparison.OrdinalIgnoreCase))
             return ParseDeclarativeRule(element);
 
-        if (type.Equals("custom", StringComparison.OrdinalIgnoreCase))
+        if (type.Equals(BuildJsonPropertyNames.Custom, StringComparison.OrdinalIgnoreCase))
             return ParseCustomRule(element);
 
         throw new InvalidOperationException(
-            $"Unknown rule type '{type}'. Supported types: 'declarative', 'custom'.");
+            $"Unknown rule type '{type}'. Supported types: '{BuildJsonPropertyNames.Declarative}', '{BuildJsonPropertyNames.Custom}'.");
     }
 
     private DeclarativeRule ParseDeclarativeRule(JsonElement element)
     {
-        var name = GetOptionalString(element, "name")
+        var name = GetOptionalString(element, BuildJsonPropertyNames.Name)
             ?? throw new InvalidOperationException(
-                "Declarative rule is missing required 'name' field.");
+                $"Declarative rule is missing required '{BuildJsonPropertyNames.Name}' field.");
 
-        var condition = GetOptionalString(element, "condition")
+        var condition = GetOptionalString(element, BuildJsonPropertyNames.Condition)
             ?? throw new InvalidOperationException(
-                $"Declarative rule '{name}' is missing required 'condition' field.");
+                $"Declarative rule '{name}' is missing required '{BuildJsonPropertyNames.Condition}' field.");
 
         var transformations = new Dictionary<string, string>();
-        if (element.TryGetProperty("transformations", out var transElement))
+        if (element.TryGetProperty(BuildJsonPropertyNames.Transformations, out var transElement))
         {
             foreach (var prop in transElement.EnumerateObject())
             {
@@ -113,13 +113,13 @@ public class RuleFileLoader
 
     private static IRule ParseCustomRule(JsonElement element)
     {
-        var assemblyPath = GetOptionalString(element, "assemblyPath")
+        var assemblyPath = GetOptionalString(element, BuildJsonPropertyNames.AssemblyPath)
             ?? throw new InvalidOperationException(
-                "Custom rule is missing required 'assemblyPath' field.");
+                $"Custom rule is missing required '{BuildJsonPropertyNames.AssemblyPath}' field.");
 
-        var className = GetOptionalString(element, "className")
+        var className = GetOptionalString(element, BuildJsonPropertyNames.ClassName)
             ?? throw new InvalidOperationException(
-                "Custom rule is missing required 'className' field.");
+                $"Custom rule is missing required '{BuildJsonPropertyNames.ClassName}' field.");
 
         Assembly assembly;
         try

--- a/tasks/tasks-console-application.md
+++ b/tasks/tasks-console-application.md
@@ -50,13 +50,13 @@ All tests must pass before moving on to the next sub-task.
   - [x] 1.2 Create `StateMaker.Console.csproj` targeting `net6.0` as an executable, referencing the `StateMaker` library project
   - [x] 1.3 Add the new project to `StateMaker.sln`
   - [x] 1.4 Verify the solution builds successfully with `dotnet build`
-- [ ] 2.0 Implement the build definition file parser
-  - [ ] 2.1 Create `BuildDefinitionLoader.cs` that parses a combined JSON file containing `initialState`, `rules`, and optional `config` sections
-  - [ ] 2.2 Parse the `initialState` section into a `State` object (reuse `RuleFileLoader` logic or call its methods)
-  - [ ] 2.3 Parse the `rules` section into an `IRule[]` array (reuse `RuleFileLoader` logic or call its methods)
-  - [ ] 2.4 Parse the optional `config` section into a `BuilderConfig` object (handle `maxStates`, `maxDepth`, `explorationStrategy` fields)
-  - [ ] 2.5 Return a result containing the initial state, rules, and config; use sensible defaults when config is omitted
-  - [ ] 2.6 Verify the build definition loader works by building the project
+- [x] 2.0 Implement the build definition file parser
+  - [x] 2.1 Create `BuildDefinitionLoader.cs` that parses a combined JSON file containing `initialState`, `rules`, and optional `config` sections
+  - [x] 2.2 Parse the `initialState` section into a `State` object (reuse `RuleFileLoader` logic or call its methods)
+  - [x] 2.3 Parse the `rules` section into an `IRule[]` array (reuse `RuleFileLoader` logic or call its methods)
+  - [x] 2.4 Parse the optional `config` section into a `BuilderConfig` object (handle `maxStates`, `maxDepth`, `explorationStrategy` fields)
+  - [x] 2.5 Return a result containing the initial state, rules, and config; use sensible defaults when config is omitted
+  - [x] 2.6 Verify the build definition loader works by building the project
 - [ ] 3.0 Implement the ExporterFactory
   - [ ] 3.1 Create `ExporterFactory.cs` that maps format strings (`json`, `dot`, `graphml`) to the corresponding `IStateMachineExporter` implementations
   - [ ] 3.2 Throw a clear error for unrecognized format strings


### PR DESCRIPTION
## Summary
- Add BuildDefinitionLoader that parses combined JSON build definition files (initialState, rules, config sections)
- Reuses RuleFileLoader for initialState and rules parsing, adds config parsing (maxStates, maxDepth, explorationStrategy)
- Create BuildJsonPropertyNames shared constants class for JSON property names used across BuildDefinitionLoader and RuleFileLoader
- Update RuleFileLoader to use shared constants instead of literal strings
- 23 new tests (671 total)

## Test plan
- [x] All 671 tests pass locally
- [x] Build succeeds with TreatWarningsAsErrors enabled

Generated with Claude Code