### PR TITLE
Add ExporterFactory, BuildCommand, and ExportCommand (tasks 3.0-5.0)

### DIFF
--- a/src/StateMaker.Tests/BuildCommandTests.cs
+++ b/src/StateMaker.Tests/BuildCommandTests.cs
@@ -1,0 +1,174 @@
+using System.IO;
+using Xunit;
+
+namespace StateMaker.Tests;
+
+public class BuildCommandTests
+{
+    private static string CreateTempDefinitionFile(string json)
+    {
+        var path = Path.GetTempFileName();
+        File.WriteAllText(path, json);
+        return path;
+    }
+
+    private static readonly string SimpleDefinition = @"{
+        ""initialState"": { ""step"": 0 },
+        ""rules"": [
+            {
+                ""name"": ""Step"",
+                ""condition"": ""step < 2"",
+                ""transformations"": { ""step"": ""step + 1"" }
+            }
+        ],
+        ""config"": { ""maxStates"": 10 }
+    }";
+
+    #region Build to stdout
+
+    [Fact]
+    public void Execute_DefaultFormat_WritesJsonToStdout()
+    {
+        var path = CreateTempDefinitionFile(SimpleDefinition);
+        try
+        {
+            var writer = new StringWriter();
+            var command = new BuildCommand();
+
+            command.Execute(path, null, "json", writer);
+
+            var output = writer.ToString();
+            Assert.Contains("startingStateId", output, StringComparison.Ordinal);
+            Assert.Contains("states", output, StringComparison.Ordinal);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Execute_DotFormat_WritesDotToStdout()
+    {
+        var path = CreateTempDefinitionFile(SimpleDefinition);
+        try
+        {
+            var writer = new StringWriter();
+            var command = new BuildCommand();
+
+            command.Execute(path, null, "dot", writer);
+
+            var output = writer.ToString();
+            Assert.Contains("digraph", output, StringComparison.Ordinal);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Execute_GraphmlFormat_WritesGraphmlToStdout()
+    {
+        var path = CreateTempDefinitionFile(SimpleDefinition);
+        try
+        {
+            var writer = new StringWriter();
+            var command = new BuildCommand();
+
+            command.Execute(path, null, "graphml", writer);
+
+            var output = writer.ToString();
+            Assert.Contains("graphml", output, StringComparison.Ordinal);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    #endregion
+
+    #region Build to file
+
+    [Fact]
+    public void Execute_WithOutputPath_WritesToFile()
+    {
+        var definitionPath = CreateTempDefinitionFile(SimpleDefinition);
+        var outputPath = Path.GetTempFileName();
+        try
+        {
+            var command = new BuildCommand();
+
+            command.Execute(definitionPath, outputPath, "json", TextWriter.Null);
+
+            var content = File.ReadAllText(outputPath);
+            Assert.Contains("startingStateId", content, StringComparison.Ordinal);
+        }
+        finally
+        {
+            File.Delete(definitionPath);
+            File.Delete(outputPath);
+        }
+    }
+
+    #endregion
+
+    #region Error cases
+
+    [Fact]
+    public void Execute_FileNotFound_ThrowsFileNotFoundException()
+    {
+        var command = new BuildCommand();
+
+        Assert.Throws<FileNotFoundException>(() =>
+            command.Execute("nonexistent.json", null, "json", TextWriter.Null));
+    }
+
+    [Fact]
+    public void Execute_InvalidFormat_ThrowsArgumentException()
+    {
+        var path = CreateTempDefinitionFile(SimpleDefinition);
+        try
+        {
+            var command = new BuildCommand();
+
+            Assert.Throws<ArgumentException>(() =>
+                command.Execute(path, null, "xml", TextWriter.Null));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    #endregion
+
+    #region State machine correctness
+
+    [Fact]
+    public void Execute_SimpleDefinition_ProducesCorrectStateCount()
+    {
+        var path = CreateTempDefinitionFile(SimpleDefinition);
+        try
+        {
+            var writer = new StringWriter();
+            var command = new BuildCommand();
+
+            command.Execute(path, null, "json", writer);
+
+            var output = writer.ToString();
+            // step 0, 1, 2 = 3 states
+            var importer = new JsonImporter();
+            var sm = importer.Import(output);
+            Assert.Equal(3, sm.States.Count);
+            Assert.Equal(2, sm.Transitions.Count);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    #endregion
+}

--- a/src/StateMaker.Tests/ExportCommandTests.cs
+++ b/src/StateMaker.Tests/ExportCommandTests.cs
@@ -1,0 +1,172 @@
+using System.IO;
+using Xunit;
+
+namespace StateMaker.Tests;
+
+public class ExportCommandTests
+{
+    private static string CreateTempStateMachineFile()
+    {
+        var sm = new StateMachine();
+        var s0 = new State();
+        s0.Variables["x"] = 0;
+        var s1 = new State();
+        s1.Variables["x"] = 1;
+        sm.AddOrUpdateState("S0", s0);
+        sm.AddOrUpdateState("S1", s1);
+        sm.StartingStateId = "S0";
+        sm.Transitions.Add(new Transition("S0", "S1", "Inc"));
+
+        var exporter = new JsonExporter();
+        var json = exporter.Export(sm);
+        var path = Path.GetTempFileName();
+        File.WriteAllText(path, json);
+        return path;
+    }
+
+    #region Export to stdout
+
+    [Fact]
+    public void Execute_JsonFormat_WritesJsonToStdout()
+    {
+        var path = CreateTempStateMachineFile();
+        try
+        {
+            var writer = new StringWriter();
+            var command = new ExportCommand();
+
+            command.Execute(path, null, "json", writer);
+
+            var output = writer.ToString();
+            Assert.Contains("startingStateId", output, StringComparison.Ordinal);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Execute_DotFormat_WritesDotToStdout()
+    {
+        var path = CreateTempStateMachineFile();
+        try
+        {
+            var writer = new StringWriter();
+            var command = new ExportCommand();
+
+            command.Execute(path, null, "dot", writer);
+
+            var output = writer.ToString();
+            Assert.Contains("digraph", output, StringComparison.Ordinal);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Execute_GraphmlFormat_WritesGraphmlToStdout()
+    {
+        var path = CreateTempStateMachineFile();
+        try
+        {
+            var writer = new StringWriter();
+            var command = new ExportCommand();
+
+            command.Execute(path, null, "graphml", writer);
+
+            var output = writer.ToString();
+            Assert.Contains("graphml", output, StringComparison.Ordinal);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    #endregion
+
+    #region Export to file
+
+    [Fact]
+    public void Execute_WithOutputPath_WritesToFile()
+    {
+        var inputPath = CreateTempStateMachineFile();
+        var outputPath = Path.GetTempFileName();
+        try
+        {
+            var command = new ExportCommand();
+
+            command.Execute(inputPath, outputPath, "dot", TextWriter.Null);
+
+            var content = File.ReadAllText(outputPath);
+            Assert.Contains("digraph", content, StringComparison.Ordinal);
+        }
+        finally
+        {
+            File.Delete(inputPath);
+            File.Delete(outputPath);
+        }
+    }
+
+    #endregion
+
+    #region Error cases
+
+    [Fact]
+    public void Execute_FileNotFound_ThrowsFileNotFoundException()
+    {
+        var command = new ExportCommand();
+
+        Assert.Throws<FileNotFoundException>(() =>
+            command.Execute("nonexistent.json", null, "json", TextWriter.Null));
+    }
+
+    [Fact]
+    public void Execute_InvalidFormat_ThrowsArgumentException()
+    {
+        var path = CreateTempStateMachineFile();
+        try
+        {
+            var command = new ExportCommand();
+
+            Assert.Throws<ArgumentException>(() =>
+                command.Execute(path, null, "xml", TextWriter.Null));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    #endregion
+
+    #region Round-trip correctness
+
+    [Fact]
+    public void Execute_JsonRoundTrip_PreservesStateMachine()
+    {
+        var path = CreateTempStateMachineFile();
+        try
+        {
+            var writer = new StringWriter();
+            var command = new ExportCommand();
+
+            command.Execute(path, null, "json", writer);
+
+            var importer = new JsonImporter();
+            var sm = importer.Import(writer.ToString());
+            Assert.Equal(2, sm.States.Count);
+            Assert.Single(sm.Transitions);
+            Assert.Equal("S0", sm.StartingStateId);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    #endregion
+}

--- a/src/StateMaker.Tests/ExporterFactoryTests.cs
+++ b/src/StateMaker.Tests/ExporterFactoryTests.cs
@@ -1,0 +1,70 @@
+using Xunit;
+
+namespace StateMaker.Tests;
+
+public class ExporterFactoryTests
+{
+    [Fact]
+    public void GetExporter_Json_ReturnsJsonExporter()
+    {
+        var exporter = ExporterFactory.GetExporter("json");
+
+        Assert.IsType<JsonExporter>(exporter);
+    }
+
+    [Fact]
+    public void GetExporter_Dot_ReturnsDotExporter()
+    {
+        var exporter = ExporterFactory.GetExporter("dot");
+
+        Assert.IsType<DotExporter>(exporter);
+    }
+
+    [Fact]
+    public void GetExporter_Graphml_ReturnsGraphMlExporter()
+    {
+        var exporter = ExporterFactory.GetExporter("graphml");
+
+        Assert.IsType<GraphMlExporter>(exporter);
+    }
+
+    [Fact]
+    public void GetExporter_CaseInsensitive_Json()
+    {
+        var exporter = ExporterFactory.GetExporter("JSON");
+
+        Assert.IsType<JsonExporter>(exporter);
+    }
+
+    [Fact]
+    public void GetExporter_CaseInsensitive_Dot()
+    {
+        var exporter = ExporterFactory.GetExporter("DOT");
+
+        Assert.IsType<DotExporter>(exporter);
+    }
+
+    [Fact]
+    public void GetExporter_CaseInsensitive_GraphMl()
+    {
+        var exporter = ExporterFactory.GetExporter("GraphML");
+
+        Assert.IsType<GraphMlExporter>(exporter);
+    }
+
+    [Fact]
+    public void GetExporter_UnknownFormat_ThrowsArgumentException()
+    {
+        var ex = Assert.Throws<ArgumentException>(() =>
+            ExporterFactory.GetExporter("xml"));
+
+        Assert.Contains("xml", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GetExporter_NullFormat_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            ExporterFactory.GetExporter(null!));
+    }
+}

--- a/src/StateMaker/BuildCommand.cs
+++ b/src/StateMaker/BuildCommand.cs
@@ -1,0 +1,21 @@
+namespace StateMaker;
+
+public class BuildCommand
+{
+    private readonly BuildDefinitionLoader _loader = new();
+
+    public void Execute(string definitionFilePath, string? outputPath, string format, TextWriter writer)
+    {
+        var result = _loader.LoadFromFile(definitionFilePath);
+        var builder = new StateMachineBuilder();
+        var stateMachine = builder.Build(result.InitialState, result.Rules, result.Config);
+
+        var exporter = ExporterFactory.GetExporter(format);
+        var output = exporter.Export(stateMachine);
+
+        if (outputPath is not null)
+            File.WriteAllText(outputPath, output);
+        else
+            writer.Write(output);
+    }
+}

--- a/src/StateMaker/ExportCommand.cs
+++ b/src/StateMaker/ExportCommand.cs
@@ -1,0 +1,23 @@
+namespace StateMaker;
+
+public class ExportCommand
+{
+    private readonly JsonImporter _importer = new();
+
+    public void Execute(string inputFilePath, string? outputPath, string format, TextWriter writer)
+    {
+        if (!File.Exists(inputFilePath))
+            throw new FileNotFoundException($"State machine file not found: {inputFilePath}", inputFilePath);
+
+        var json = File.ReadAllText(inputFilePath);
+        var stateMachine = _importer.Import(json);
+
+        var exporter = ExporterFactory.GetExporter(format);
+        var output = exporter.Export(stateMachine);
+
+        if (outputPath is not null)
+            File.WriteAllText(outputPath, output);
+        else
+            writer.Write(output);
+    }
+}

--- a/src/StateMaker/ExporterFactory.cs
+++ b/src/StateMaker/ExporterFactory.cs
@@ -1,0 +1,18 @@
+namespace StateMaker;
+
+public static class ExporterFactory
+{
+    public static IStateMachineExporter GetExporter(string format)
+    {
+        ArgumentNullException.ThrowIfNull(format);
+
+        return format.ToUpperInvariant() switch
+        {
+            "JSON" => new JsonExporter(),
+            "DOT" => new DotExporter(),
+            "GRAPHML" => new GraphMlExporter(),
+            _ => throw new ArgumentException(
+                $"Unsupported export format '{format}'. Supported formats: json, dot, graphml.", nameof(format))
+        };
+    }
+}

--- a/tasks/tasks-console-application.md
+++ b/tasks/tasks-console-application.md
@@ -57,20 +57,20 @@ All tests must pass before moving on to the next sub-task.
   - [x] 2.4 Parse the optional `config` section into a `BuilderConfig` object (handle `maxStates`, `maxDepth`, `explorationStrategy` fields)
   - [x] 2.5 Return a result containing the initial state, rules, and config; use sensible defaults when config is omitted
   - [x] 2.6 Verify the build definition loader works by building the project
-- [ ] 3.0 Implement the ExporterFactory
-  - [ ] 3.1 Create `ExporterFactory.cs` that maps format strings (`json`, `dot`, `graphml`) to the corresponding `IStateMachineExporter` implementations
-  - [ ] 3.2 Throw a clear error for unrecognized format strings
-- [ ] 4.0 Implement the build command
-  - [ ] 4.1 Create `BuildCommand.cs` that accepts a definition file path, optional output path, and optional format string
-  - [ ] 4.2 Use `BuildDefinitionLoader` to parse the definition file
-  - [ ] 4.3 Use `StateMachineBuilder.Build()` to build the state machine from the parsed initial state, rules, and config
-  - [ ] 4.4 Use `ExporterFactory` to get the appropriate exporter and export the state machine
-  - [ ] 4.5 Write the exported content to the output file if `--output` is specified, otherwise write to stdout
-- [ ] 5.0 Implement the export command
-  - [ ] 5.1 Create `ExportCommand.cs` that accepts a JSON state machine file path, required format string, and optional output path
-  - [ ] 5.2 Read the input file and use `JsonImporter` to load the state machine
-  - [ ] 5.3 Use `ExporterFactory` to get the appropriate exporter and export the state machine
-  - [ ] 5.4 Write the exported content to the output file if `--output` is specified, otherwise write to stdout
+- [x] 3.0 Implement the ExporterFactory
+  - [x] 3.1 Create `ExporterFactory.cs` that maps format strings (`json`, `dot`, `graphml`) to the corresponding `IStateMachineExporter` implementations
+  - [x] 3.2 Throw a clear error for unrecognized format strings
+- [x] 4.0 Implement the build command
+  - [x] 4.1 Create `BuildCommand.cs` that accepts a definition file path, optional output path, and optional format string
+  - [x] 4.2 Use `BuildDefinitionLoader` to parse the definition file
+  - [x] 4.3 Use `StateMachineBuilder.Build()` to build the state machine from the parsed initial state, rules, and config
+  - [x] 4.4 Use `ExporterFactory` to get the appropriate exporter and export the state machine
+  - [x] 4.5 Write the exported content to the output file if `--output` is specified, otherwise write to stdout
+- [x] 5.0 Implement the export command
+  - [x] 5.1 Create `ExportCommand.cs` that accepts a JSON state machine file path, required format string, and optional output path
+  - [x] 5.2 Read the input file and use `JsonImporter` to load the state machine
+  - [x] 5.3 Use `ExporterFactory` to get the appropriate exporter and export the state machine
+  - [x] 5.4 Write the exported content to the output file if `--output` is specified, otherwise write to stdout
 - [ ] 6.0 Implement help content and argument routing
   - [ ] 6.1 Create `HelpPrinter.cs` that prints usage syntax, command descriptions, options, and examples to stdout
   - [ ] 6.2 Implement `Program.cs` with argument parsing that routes to `build`, `export`, or help based on the first argument


### PR DESCRIPTION
## Summary
- Add ExporterFactory: maps format strings (json, dot, graphml) to exporter instances, case-insensitive
- Add BuildCommand: loads build definition file, builds state machine, exports to specified format
- Add ExportCommand: loads pre-built JSON state machine, re-exports to specified format
- Both commands support output to file or stdout via TextWriter
- 22 new tests (693 total)

## Test plan
- [x] All 693 tests pass locally
- [x] Build succeeds with TreatWarningsAsErrors enabled

Generated with Claude Code