### PR TITLE
Add help content, argument routing, and error handling (tasks 6.0, 7.0)

### DIFF
--- a/src/StateMaker.Console/Program.cs
+++ b/src/StateMaker.Console/Program.cs
@@ -1,9 +1,90 @@
+using StateMaker;
+
 namespace StateMaker.Console;
 
 public class Program
 {
     public static int Main(string[] args)
     {
+        return Run(args, System.Console.Out, System.Console.Error);
+    }
+
+    public static int Run(string[] args, TextWriter stdout, TextWriter stderr)
+    {
+        if (args.Length == 0)
+        {
+            HelpPrinter.PrintHelp(stdout);
+            return 0;
+        }
+
+        var command = args[0].ToLowerInvariant();
+
+        try
+        {
+            switch (command)
+            {
+                case "build":
+                    return RunBuild(args, stdout, stderr);
+                case "export":
+                    return RunExport(args, stdout, stderr);
+                default:
+                    stderr.WriteLine($"Unknown command '{args[0]}'.");
+                    stderr.WriteLine();
+                    HelpPrinter.PrintHelp(stderr);
+                    return 1;
+            }
+        }
+        catch (Exception ex)
+        {
+            stderr.WriteLine(ex.ToString());
+            return 1;
+        }
+    }
+
+    private static int RunBuild(string[] args, TextWriter stdout, TextWriter stderr)
+    {
+        if (args.Length < 2)
+        {
+            stderr.WriteLine("Error: build command requires a definition file path.");
+            return 1;
+        }
+
+        var filePath = args[1];
+        var format = GetOptionValue(args, "--format", "-f") ?? "json";
+        var outputPath = GetOptionValue(args, "--output", "-o");
+
+        var buildCommand = new BuildCommand();
+        buildCommand.Execute(filePath, outputPath, format, stdout);
         return 0;
+    }
+
+    private static int RunExport(string[] args, TextWriter stdout, TextWriter stderr)
+    {
+        if (args.Length < 2)
+        {
+            stderr.WriteLine("Error: export command requires a state machine file path.");
+            return 1;
+        }
+
+        var filePath = args[1];
+        var format = GetOptionValue(args, "--format", "-f") ?? "json";
+        var outputPath = GetOptionValue(args, "--output", "-o");
+
+        var exportCommand = new ExportCommand();
+        exportCommand.Execute(filePath, outputPath, format, stdout);
+        return 0;
+    }
+
+    private static string? GetOptionValue(string[] args, string longFlag, string shortFlag)
+    {
+        for (int i = 0; i < args.Length - 1; i++)
+        {
+            if (string.Equals(args[i], longFlag, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(args[i], shortFlag, StringComparison.OrdinalIgnoreCase))
+            {
+                return args[i + 1];
+            }
+        }
+        return null;
     }
 }

--- a/src/StateMaker.Tests/HelpPrinterTests.cs
+++ b/src/StateMaker.Tests/HelpPrinterTests.cs
@@ -1,0 +1,72 @@
+using Xunit;
+
+namespace StateMaker.Tests;
+
+public class HelpPrinterTests
+{
+    [Fact]
+    public void PrintHelp_ContainsUsageSyntax()
+    {
+        var writer = new StringWriter();
+
+        HelpPrinter.PrintHelp(writer);
+
+        var output = writer.ToString();
+        Assert.Contains("Usage:", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PrintHelp_ContainsBuildCommand()
+    {
+        var writer = new StringWriter();
+
+        HelpPrinter.PrintHelp(writer);
+
+        var output = writer.ToString();
+        Assert.Contains("build", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PrintHelp_ContainsExportCommand()
+    {
+        var writer = new StringWriter();
+
+        HelpPrinter.PrintHelp(writer);
+
+        var output = writer.ToString();
+        Assert.Contains("export", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PrintHelp_ContainsFormatOption()
+    {
+        var writer = new StringWriter();
+
+        HelpPrinter.PrintHelp(writer);
+
+        var output = writer.ToString();
+        Assert.Contains("--format", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PrintHelp_ContainsOutputOption()
+    {
+        var writer = new StringWriter();
+
+        HelpPrinter.PrintHelp(writer);
+
+        var output = writer.ToString();
+        Assert.Contains("--output", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PrintHelp_ContainsExamples()
+    {
+        var writer = new StringWriter();
+
+        HelpPrinter.PrintHelp(writer);
+
+        var output = writer.ToString();
+        Assert.Contains("Examples:", output, StringComparison.Ordinal);
+    }
+}

--- a/src/StateMaker.Tests/LoggerTests.cs
+++ b/src/StateMaker.Tests/LoggerTests.cs
@@ -63,7 +63,7 @@ public class LoggerTests
     public void ConsoleLogger_InfoLevel_WritesInfoAndError()
     {
         var output = new StringWriter();
-        Console.SetOut(output);
+        System.Console.SetOut(output);
         try
         {
             var logger = new ConsoleLogger(LogLevel.INFO);
@@ -78,7 +78,7 @@ public class LoggerTests
         }
         finally
         {
-            Console.SetOut(new StreamWriter(Console.OpenStandardOutput()) { AutoFlush = true });
+            System.Console.SetOut(new StreamWriter(System.Console.OpenStandardOutput()) { AutoFlush = true });
         }
     }
 
@@ -86,7 +86,7 @@ public class LoggerTests
     public void ConsoleLogger_DebugLevel_WritesAll()
     {
         var output = new StringWriter();
-        Console.SetOut(output);
+        System.Console.SetOut(output);
         try
         {
             var logger = new ConsoleLogger(LogLevel.DEBUG);
@@ -101,7 +101,7 @@ public class LoggerTests
         }
         finally
         {
-            Console.SetOut(new StreamWriter(Console.OpenStandardOutput()) { AutoFlush = true });
+            System.Console.SetOut(new StreamWriter(System.Console.OpenStandardOutput()) { AutoFlush = true });
         }
     }
 
@@ -109,7 +109,7 @@ public class LoggerTests
     public void ConsoleLogger_ErrorLevel_WritesErrorOnly()
     {
         var output = new StringWriter();
-        Console.SetOut(output);
+        System.Console.SetOut(output);
         try
         {
             var logger = new ConsoleLogger(LogLevel.ERROR);
@@ -124,7 +124,7 @@ public class LoggerTests
         }
         finally
         {
-            Console.SetOut(new StreamWriter(Console.OpenStandardOutput()) { AutoFlush = true });
+            System.Console.SetOut(new StreamWriter(System.Console.OpenStandardOutput()) { AutoFlush = true });
         }
     }
 
@@ -132,7 +132,7 @@ public class LoggerTests
     public void ConsoleLogger_DefaultLevel_IsInfo()
     {
         var output = new StringWriter();
-        Console.SetOut(output);
+        System.Console.SetOut(output);
         try
         {
             var logger = new ConsoleLogger();
@@ -145,7 +145,7 @@ public class LoggerTests
         }
         finally
         {
-            Console.SetOut(new StreamWriter(Console.OpenStandardOutput()) { AutoFlush = true });
+            System.Console.SetOut(new StreamWriter(System.Console.OpenStandardOutput()) { AutoFlush = true });
         }
     }
 

--- a/src/StateMaker.Tests/ProgramTests.cs
+++ b/src/StateMaker.Tests/ProgramTests.cs
@@ -1,0 +1,294 @@
+using System.IO;
+using StateMaker.Console;
+using Xunit;
+
+namespace StateMaker.Tests;
+
+public class ProgramTests
+{
+    #region Help / No Arguments
+
+    [Fact]
+    public void Run_NoArguments_PrintsHelpAndReturnsZero()
+    {
+        var stdout = new StringWriter();
+        var stderr = new StringWriter();
+
+        int exitCode = Program.Run(Array.Empty<string>(), stdout, stderr);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Usage:", stdout.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Run_UnknownCommand_PrintsHelpAndReturnsOne()
+    {
+        var stdout = new StringWriter();
+        var stderr = new StringWriter();
+
+        int exitCode = Program.Run(new[] { "unknown" }, stdout, stderr);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Unknown command", stderr.ToString(), StringComparison.Ordinal);
+    }
+
+    #endregion
+
+    #region Build Command Routing
+
+    [Fact]
+    public void Run_BuildCommand_WithDefinitionFile_ReturnsZero()
+    {
+        var definitionPath = Path.GetTempFileName();
+        File.WriteAllText(definitionPath, @"{
+            ""initialState"": { ""x"": 0 },
+            ""rules"": [
+                { ""name"": ""Inc"", ""condition"": ""x < 1"", ""transformations"": { ""x"": ""x + 1"" } }
+            ]
+        }");
+        try
+        {
+            var stdout = new StringWriter();
+            var stderr = new StringWriter();
+
+            int exitCode = Program.Run(new[] { "build", definitionPath }, stdout, stderr);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("startingStateId", stdout.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            File.Delete(definitionPath);
+        }
+    }
+
+    [Fact]
+    public void Run_BuildCommand_WithFormatFlag_UsesSpecifiedFormat()
+    {
+        var definitionPath = Path.GetTempFileName();
+        File.WriteAllText(definitionPath, @"{
+            ""initialState"": { ""x"": 0 },
+            ""rules"": [
+                { ""name"": ""Inc"", ""condition"": ""x < 1"", ""transformations"": { ""x"": ""x + 1"" } }
+            ]
+        }");
+        try
+        {
+            var stdout = new StringWriter();
+            var stderr = new StringWriter();
+
+            int exitCode = Program.Run(new[] { "build", definitionPath, "--format", "dot" }, stdout, stderr);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("digraph", stdout.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            File.Delete(definitionPath);
+        }
+    }
+
+    [Fact]
+    public void Run_BuildCommand_WithShortFormatFlag_UsesSpecifiedFormat()
+    {
+        var definitionPath = Path.GetTempFileName();
+        File.WriteAllText(definitionPath, @"{
+            ""initialState"": { ""x"": 0 },
+            ""rules"": [
+                { ""name"": ""Inc"", ""condition"": ""x < 1"", ""transformations"": { ""x"": ""x + 1"" } }
+            ]
+        }");
+        try
+        {
+            var stdout = new StringWriter();
+            var stderr = new StringWriter();
+
+            int exitCode = Program.Run(new[] { "build", definitionPath, "-f", "dot" }, stdout, stderr);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("digraph", stdout.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            File.Delete(definitionPath);
+        }
+    }
+
+    [Fact]
+    public void Run_BuildCommand_WithOutputFlag_WritesToFile()
+    {
+        var definitionPath = Path.GetTempFileName();
+        var outputPath = Path.GetTempFileName();
+        File.WriteAllText(definitionPath, @"{
+            ""initialState"": { ""x"": 0 },
+            ""rules"": [
+                { ""name"": ""Inc"", ""condition"": ""x < 1"", ""transformations"": { ""x"": ""x + 1"" } }
+            ]
+        }");
+        try
+        {
+            var stdout = new StringWriter();
+            var stderr = new StringWriter();
+
+            int exitCode = Program.Run(new[] { "build", definitionPath, "--output", outputPath }, stdout, stderr);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("startingStateId", File.ReadAllText(outputPath), StringComparison.Ordinal);
+        }
+        finally
+        {
+            File.Delete(definitionPath);
+            File.Delete(outputPath);
+        }
+    }
+
+    [Fact]
+    public void Run_BuildCommand_WithShortOutputFlag_WritesToFile()
+    {
+        var definitionPath = Path.GetTempFileName();
+        var outputPath = Path.GetTempFileName();
+        File.WriteAllText(definitionPath, @"{
+            ""initialState"": { ""x"": 0 },
+            ""rules"": [
+                { ""name"": ""Inc"", ""condition"": ""x < 1"", ""transformations"": { ""x"": ""x + 1"" } }
+            ]
+        }");
+        try
+        {
+            var stdout = new StringWriter();
+            var stderr = new StringWriter();
+
+            int exitCode = Program.Run(new[] { "build", definitionPath, "-o", outputPath }, stdout, stderr);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("startingStateId", File.ReadAllText(outputPath), StringComparison.Ordinal);
+        }
+        finally
+        {
+            File.Delete(definitionPath);
+            File.Delete(outputPath);
+        }
+    }
+
+    [Fact]
+    public void Run_BuildCommand_MissingFilePath_ReturnsOne()
+    {
+        var stdout = new StringWriter();
+        var stderr = new StringWriter();
+
+        int exitCode = Program.Run(new[] { "build" }, stdout, stderr);
+
+        Assert.Equal(1, exitCode);
+        Assert.NotEmpty(stderr.ToString());
+    }
+
+    #endregion
+
+    #region Export Command Routing
+
+    [Fact]
+    public void Run_ExportCommand_WithJsonFile_ReturnsZero()
+    {
+        var sm = new StateMachine();
+        var s0 = new State();
+        s0.Variables["x"] = 0;
+        sm.AddOrUpdateState("S0", s0);
+        sm.StartingStateId = "S0";
+        var json = new JsonExporter().Export(sm);
+        var inputPath = Path.GetTempFileName();
+        File.WriteAllText(inputPath, json);
+        try
+        {
+            var stdout = new StringWriter();
+            var stderr = new StringWriter();
+
+            int exitCode = Program.Run(new[] { "export", inputPath, "--format", "dot" }, stdout, stderr);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("digraph", stdout.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            File.Delete(inputPath);
+        }
+    }
+
+    [Fact]
+    public void Run_ExportCommand_MissingFilePath_ReturnsOne()
+    {
+        var stdout = new StringWriter();
+        var stderr = new StringWriter();
+
+        int exitCode = Program.Run(new[] { "export" }, stdout, stderr);
+
+        Assert.Equal(1, exitCode);
+        Assert.NotEmpty(stderr.ToString());
+    }
+
+    [Fact]
+    public void Run_ExportCommand_MissingFormatFlag_DefaultsToJson()
+    {
+        var sm = new StateMachine();
+        var s0 = new State();
+        s0.Variables["x"] = 0;
+        sm.AddOrUpdateState("S0", s0);
+        sm.StartingStateId = "S0";
+        var json = new JsonExporter().Export(sm);
+        var inputPath = Path.GetTempFileName();
+        File.WriteAllText(inputPath, json);
+        try
+        {
+            var stdout = new StringWriter();
+            var stderr = new StringWriter();
+
+            int exitCode = Program.Run(new[] { "export", inputPath }, stdout, stderr);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("startingStateId", stdout.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            File.Delete(inputPath);
+        }
+    }
+
+    #endregion
+
+    #region Error Handling
+
+    [Fact]
+    public void Run_BuildCommand_FileNotFound_ReturnsOneWithStackTrace()
+    {
+        var stdout = new StringWriter();
+        var stderr = new StringWriter();
+
+        int exitCode = Program.Run(new[] { "build", "nonexistent.json" }, stdout, stderr);
+
+        Assert.Equal(1, exitCode);
+        var errorOutput = stderr.ToString();
+        Assert.Contains("not found", errorOutput, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Run_BuildCommand_InvalidJson_ReturnsOne()
+    {
+        var path = Path.GetTempFileName();
+        File.WriteAllText(path, "not valid json");
+        try
+        {
+            var stdout = new StringWriter();
+            var stderr = new StringWriter();
+
+            int exitCode = Program.Run(new[] { "build", path }, stdout, stderr);
+
+            Assert.Equal(1, exitCode);
+            Assert.NotEmpty(stderr.ToString());
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    #endregion
+}

--- a/src/StateMaker.Tests/StateMaker.Tests.csproj
+++ b/src/StateMaker.Tests/StateMaker.Tests.csproj
@@ -7,7 +7,7 @@
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
-    <NoWarn>CA1707</NoWarn>
+    <NoWarn>CA1707;CA1861</NoWarn>
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 
@@ -24,6 +24,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\StateMaker\StateMaker.csproj" />
+    <ProjectReference Include="..\StateMaker.Console\StateMaker.Console.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/StateMaker/HelpPrinter.cs
+++ b/src/StateMaker/HelpPrinter.cs
@@ -1,0 +1,22 @@
+namespace StateMaker;
+
+public static class HelpPrinter
+{
+    public static void PrintHelp(TextWriter writer)
+    {
+        writer.WriteLine("Usage: statemaker <command> [options]");
+        writer.WriteLine();
+        writer.WriteLine("Commands:");
+        writer.WriteLine("  build <file>     Build a state machine from a definition file");
+        writer.WriteLine("  export <file>    Load a JSON state machine and export to another format");
+        writer.WriteLine();
+        writer.WriteLine("Options:");
+        writer.WriteLine("  --format, -f <format>   Export format: json, dot, graphml (default: json)");
+        writer.WriteLine("  --output, -o <file>     Output file path (default: stdout)");
+        writer.WriteLine();
+        writer.WriteLine("Examples:");
+        writer.WriteLine("  statemaker build definition.json");
+        writer.WriteLine("  statemaker build definition.json --format dot --output graph.dot");
+        writer.WriteLine("  statemaker export machine.json --format graphml -o machine.graphml");
+    }
+}

--- a/tasks/tasks-console-application.md
+++ b/tasks/tasks-console-application.md
@@ -71,16 +71,16 @@ All tests must pass before moving on to the next sub-task.
   - [x] 5.2 Read the input file and use `JsonImporter` to load the state machine
   - [x] 5.3 Use `ExporterFactory` to get the appropriate exporter and export the state machine
   - [x] 5.4 Write the exported content to the output file if `--output` is specified, otherwise write to stdout
-- [ ] 6.0 Implement help content and argument routing
-  - [ ] 6.1 Create `HelpPrinter.cs` that prints usage syntax, command descriptions, options, and examples to stdout
-  - [ ] 6.2 Implement `Program.cs` with argument parsing that routes to `build`, `export`, or help based on the first argument
-  - [ ] 6.3 Parse `--output`/`-o` and `--format`/`-f` flags from the argument array
-  - [ ] 6.4 Print help when no arguments are provided or when an unrecognized command is given
-- [ ] 7.0 Implement error handling
-  - [ ] 7.1 Wrap command execution in try/catch in `Program.cs`
-  - [ ] 7.2 On error, print the exception message and full stack trace to stderr
-  - [ ] 7.3 Return exit code 1 on error, exit code 0 on success
-  - [ ] 7.4 Handle specific error cases: missing file path argument, file not found, invalid JSON, unsupported format
+- [x] 6.0 Implement help content and argument routing
+  - [x] 6.1 Create `HelpPrinter.cs` that prints usage syntax, command descriptions, options, and examples to stdout
+  - [x] 6.2 Implement `Program.cs` with argument parsing that routes to `build`, `export`, or help based on the first argument
+  - [x] 6.3 Parse `--output`/`-o` and `--format`/`-f` flags from the argument array
+  - [x] 6.4 Print help when no arguments are provided or when an unrecognized command is given
+- [x] 7.0 Implement error handling
+  - [x] 7.1 Wrap command execution in try/catch in `Program.cs`
+  - [x] 7.2 On error, print the exception message and full stack trace to stderr
+  - [x] 7.3 Return exit code 1 on error, exit code 0 on success
+  - [x] 7.4 Handle specific error cases: missing file path argument, file not found, invalid JSON, unsupported format
 - [ ] 8.0 End-to-end testing with sample definition files
   - [ ] 8.1 Create a sample build definition file (`samples/simple-build.json`) with a small state machine definition
   - [ ] 8.2 Test the `build` command: build from definition file with default format (JSON), verify output


### PR DESCRIPTION
## Summary
- Add HelpPrinter with usage syntax, command descriptions, options, and examples
- Implement Program.Run with testable TextWriter params for argument parsing and command routing
- Parse --format/-f and --output/-o flags from argument array
- Print help on no arguments, error on unknown commands
- Wrap command execution in try/catch with full exception output to stderr
- Return exit code 1 on error, 0 on success
- Fix System.Console namespace collision in LoggerTests caused by StateMaker.Console project reference
- 19 new tests (712 total)

## Test plan
- [x] All 712 tests pass locally
- [x] Build succeeds with TreatWarningsAsErrors enabled

Generated with Claude Code