### PR TITLE
Add end-to-end tests and sample definition file (task 8.0)

### DIFF
--- a/samples/simple-build.json
+++ b/samples/simple-build.json
@@ -1,0 +1,26 @@
+{
+  "initialState": {
+    "step": 0,
+    "done": false
+  },
+  "rules": [
+    {
+      "name": "Advance",
+      "condition": "step < 3",
+      "transformations": {
+        "step": "step + 1"
+      }
+    },
+    {
+      "name": "Finish",
+      "condition": "step == 3 && done == false",
+      "transformations": {
+        "done": "true"
+      }
+    }
+  ],
+  "config": {
+    "maxStates": 20,
+    "explorationStrategy": "BreadthFirstSearch"
+  }
+}

--- a/src/StateMaker.Tests/EndToEndTests.cs
+++ b/src/StateMaker.Tests/EndToEndTests.cs
@@ -1,0 +1,377 @@
+using System.IO;
+using StateMaker.Console;
+using Xunit;
+
+namespace StateMaker.Tests;
+
+public class EndToEndTests
+{
+    private static string CreateTempFile(string content)
+    {
+        var path = Path.GetTempFileName();
+        File.WriteAllText(path, content);
+        return path;
+    }
+
+    private static readonly string SampleDefinition = @"{
+        ""initialState"": { ""step"": 0, ""done"": false },
+        ""rules"": [
+            {
+                ""name"": ""Advance"",
+                ""condition"": ""step < 3"",
+                ""transformations"": { ""step"": ""step + 1"" }
+            },
+            {
+                ""name"": ""Finish"",
+                ""condition"": ""step == 3 && done == false"",
+                ""transformations"": { ""done"": ""true"" }
+            }
+        ],
+        ""config"": { ""maxStates"": 20, ""explorationStrategy"": ""BreadthFirstSearch"" }
+    }";
+
+    #region 8.2 — Build with default format (JSON)
+
+    [Fact]
+    public void Build_DefaultFormat_OutputsValidJson()
+    {
+        var path = CreateTempFile(SampleDefinition);
+        try
+        {
+            var stdout = new StringWriter();
+            var stderr = new StringWriter();
+
+            int exitCode = Program.Run(new[] { "build", path }, stdout, stderr);
+
+            Assert.Equal(0, exitCode);
+            Assert.Empty(stderr.ToString());
+
+            var output = stdout.ToString();
+            var importer = new JsonImporter();
+            var sm = importer.Import(output);
+
+            // step=0, step=1, step=2, step=3, step=3+done=true = 5 states
+            Assert.Equal(5, sm.States.Count);
+            Assert.True(sm.IsValidMachine());
+            Assert.NotNull(sm.StartingStateId);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    #endregion
+
+    #region 8.3 — Build with --format dot and --format graphml
+
+    [Fact]
+    public void Build_DotFormat_OutputsValidDot()
+    {
+        var path = CreateTempFile(SampleDefinition);
+        try
+        {
+            var stdout = new StringWriter();
+            var stderr = new StringWriter();
+
+            int exitCode = Program.Run(new[] { "build", path, "--format", "dot" }, stdout, stderr);
+
+            Assert.Equal(0, exitCode);
+            Assert.Empty(stderr.ToString());
+
+            var output = stdout.ToString();
+            Assert.Contains("digraph", output, StringComparison.Ordinal);
+            Assert.Contains("Advance", output, StringComparison.Ordinal);
+            Assert.Contains("Finish", output, StringComparison.Ordinal);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Build_GraphmlFormat_OutputsValidGraphml()
+    {
+        var path = CreateTempFile(SampleDefinition);
+        try
+        {
+            var stdout = new StringWriter();
+            var stderr = new StringWriter();
+
+            int exitCode = Program.Run(new[] { "build", path, "--format", "graphml" }, stdout, stderr);
+
+            Assert.Equal(0, exitCode);
+            Assert.Empty(stderr.ToString());
+
+            var output = stdout.ToString();
+            Assert.Contains("graphml", output, StringComparison.Ordinal);
+            Assert.Contains("node", output, StringComparison.Ordinal);
+            Assert.Contains("edge", output, StringComparison.Ordinal);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    #endregion
+
+    #region 8.4 — Build with --output flag
+
+    [Fact]
+    public void Build_WithOutputFlag_CreatesFile()
+    {
+        var definitionPath = CreateTempFile(SampleDefinition);
+        var outputPath = Path.GetTempFileName();
+        try
+        {
+            var stdout = new StringWriter();
+            var stderr = new StringWriter();
+
+            int exitCode = Program.Run(
+                new[] { "build", definitionPath, "--output", outputPath }, stdout, stderr);
+
+            Assert.Equal(0, exitCode);
+            Assert.Empty(stderr.ToString());
+
+            var content = File.ReadAllText(outputPath);
+            Assert.NotEmpty(content);
+
+            var importer = new JsonImporter();
+            var sm = importer.Import(content);
+            Assert.Equal(5, sm.States.Count);
+        }
+        finally
+        {
+            File.Delete(definitionPath);
+            File.Delete(outputPath);
+        }
+    }
+
+    [Fact]
+    public void Build_WithOutputAndFormat_CreatesFileInFormat()
+    {
+        var definitionPath = CreateTempFile(SampleDefinition);
+        var outputPath = Path.GetTempFileName();
+        try
+        {
+            var stdout = new StringWriter();
+            var stderr = new StringWriter();
+
+            int exitCode = Program.Run(
+                new[] { "build", definitionPath, "-o", outputPath, "-f", "dot" }, stdout, stderr);
+
+            Assert.Equal(0, exitCode);
+
+            var content = File.ReadAllText(outputPath);
+            Assert.Contains("digraph", content, StringComparison.Ordinal);
+        }
+        finally
+        {
+            File.Delete(definitionPath);
+            File.Delete(outputPath);
+        }
+    }
+
+    #endregion
+
+    #region 8.5 — Export command
+
+    [Fact]
+    public void Export_JsonToDot_ProducesValidDot()
+    {
+        // First build a state machine JSON
+        var definitionPath = CreateTempFile(SampleDefinition);
+        var jsonOutputPath = Path.GetTempFileName();
+        try
+        {
+            Program.Run(
+                new[] { "build", definitionPath, "-o", jsonOutputPath },
+                TextWriter.Null, TextWriter.Null);
+
+            // Now export the JSON to DOT
+            var stdout = new StringWriter();
+            var stderr = new StringWriter();
+
+            int exitCode = Program.Run(
+                new[] { "export", jsonOutputPath, "--format", "dot" }, stdout, stderr);
+
+            Assert.Equal(0, exitCode);
+            Assert.Empty(stderr.ToString());
+
+            var output = stdout.ToString();
+            Assert.Contains("digraph", output, StringComparison.Ordinal);
+            Assert.Contains("Advance", output, StringComparison.Ordinal);
+        }
+        finally
+        {
+            File.Delete(definitionPath);
+            File.Delete(jsonOutputPath);
+        }
+    }
+
+    [Fact]
+    public void Export_JsonToGraphml_ProducesValidGraphml()
+    {
+        var definitionPath = CreateTempFile(SampleDefinition);
+        var jsonOutputPath = Path.GetTempFileName();
+        try
+        {
+            Program.Run(
+                new[] { "build", definitionPath, "-o", jsonOutputPath },
+                TextWriter.Null, TextWriter.Null);
+
+            var stdout = new StringWriter();
+            var stderr = new StringWriter();
+
+            int exitCode = Program.Run(
+                new[] { "export", jsonOutputPath, "-f", "graphml" }, stdout, stderr);
+
+            Assert.Equal(0, exitCode);
+            Assert.Empty(stderr.ToString());
+
+            var output = stdout.ToString();
+            Assert.Contains("graphml", output, StringComparison.Ordinal);
+        }
+        finally
+        {
+            File.Delete(definitionPath);
+            File.Delete(jsonOutputPath);
+        }
+    }
+
+    [Fact]
+    public void Export_WithOutputFlag_CreatesFile()
+    {
+        var definitionPath = CreateTempFile(SampleDefinition);
+        var jsonOutputPath = Path.GetTempFileName();
+        var dotOutputPath = Path.GetTempFileName();
+        try
+        {
+            Program.Run(
+                new[] { "build", definitionPath, "-o", jsonOutputPath },
+                TextWriter.Null, TextWriter.Null);
+
+            var stdout = new StringWriter();
+            var stderr = new StringWriter();
+
+            int exitCode = Program.Run(
+                new[] { "export", jsonOutputPath, "-f", "dot", "-o", dotOutputPath }, stdout, stderr);
+
+            Assert.Equal(0, exitCode);
+
+            var content = File.ReadAllText(dotOutputPath);
+            Assert.Contains("digraph", content, StringComparison.Ordinal);
+        }
+        finally
+        {
+            File.Delete(definitionPath);
+            File.Delete(jsonOutputPath);
+            File.Delete(dotOutputPath);
+        }
+    }
+
+    #endregion
+
+    #region 8.6 — No arguments shows help
+
+    [Fact]
+    public void NoArguments_DisplaysHelp()
+    {
+        var stdout = new StringWriter();
+        var stderr = new StringWriter();
+
+        int exitCode = Program.Run(Array.Empty<string>(), stdout, stderr);
+
+        Assert.Equal(0, exitCode);
+        Assert.Empty(stderr.ToString());
+
+        var output = stdout.ToString();
+        Assert.Contains("Usage:", output, StringComparison.Ordinal);
+        Assert.Contains("build", output, StringComparison.Ordinal);
+        Assert.Contains("export", output, StringComparison.Ordinal);
+    }
+
+    #endregion
+
+    #region 8.7 — Error cases
+
+    [Fact]
+    public void Build_MissingFile_ReturnsErrorWithMessage()
+    {
+        var stdout = new StringWriter();
+        var stderr = new StringWriter();
+
+        int exitCode = Program.Run(new[] { "build", "does-not-exist.json" }, stdout, stderr);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("not found", stderr.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Build_InvalidJson_ReturnsError()
+    {
+        var path = CreateTempFile("{ this is not valid json }");
+        try
+        {
+            var stdout = new StringWriter();
+            var stderr = new StringWriter();
+
+            int exitCode = Program.Run(new[] { "build", path }, stdout, stderr);
+
+            Assert.Equal(1, exitCode);
+            Assert.NotEmpty(stderr.ToString());
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Build_BadFormat_ReturnsError()
+    {
+        var path = CreateTempFile(SampleDefinition);
+        try
+        {
+            var stdout = new StringWriter();
+            var stderr = new StringWriter();
+
+            int exitCode = Program.Run(new[] { "build", path, "--format", "xml" }, stdout, stderr);
+
+            Assert.Equal(1, exitCode);
+            Assert.Contains("xml", stderr.ToString(), StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Export_MissingFile_ReturnsError()
+    {
+        var stdout = new StringWriter();
+        var stderr = new StringWriter();
+
+        int exitCode = Program.Run(new[] { "export", "missing.json", "-f", "dot" }, stdout, stderr);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("not found", stderr.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void UnknownCommand_ReturnsError()
+    {
+        var stdout = new StringWriter();
+        var stderr = new StringWriter();
+
+        int exitCode = Program.Run(new[] { "destroy" }, stdout, stderr);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Unknown command", stderr.ToString(), StringComparison.Ordinal);
+    }
+
+    #endregion
+}

--- a/tasks/tasks-console-application.md
+++ b/tasks/tasks-console-application.md
@@ -81,12 +81,12 @@ All tests must pass before moving on to the next sub-task.
   - [x] 7.2 On error, print the exception message and full stack trace to stderr
   - [x] 7.3 Return exit code 1 on error, exit code 0 on success
   - [x] 7.4 Handle specific error cases: missing file path argument, file not found, invalid JSON, unsupported format
-- [ ] 8.0 End-to-end testing with sample definition files
-  - [ ] 8.1 Create a sample build definition file (`samples/simple-build.json`) with a small state machine definition
-  - [ ] 8.2 Test the `build` command: build from definition file with default format (JSON), verify output
-  - [ ] 8.3 Test the `build` command with `--format dot` and `--format graphml`, verify output
-  - [ ] 8.4 Test the `build` command with `--output` flag, verify file is created
-  - [ ] 8.5 Test the `export` command: export a JSON state machine to DOT and GraphML formats
-  - [ ] 8.6 Test running with no arguments, verify help content is displayed
-  - [ ] 8.7 Test error cases: missing file, invalid JSON, bad format string
-  - [ ] 8.8 Verify all existing library tests still pass with `dotnet test`
+- [x] 8.0 End-to-end testing with sample definition files
+  - [x] 8.1 Create a sample build definition file (`samples/simple-build.json`) with a small state machine definition
+  - [x] 8.2 Test the `build` command: build from definition file with default format (JSON), verify output
+  - [x] 8.3 Test the `build` command with `--format dot` and `--format graphml`, verify output
+  - [x] 8.4 Test the `build` command with `--output` flag, verify file is created
+  - [x] 8.5 Test the `export` command: export a JSON state machine to DOT and GraphML formats
+  - [x] 8.6 Test running with no arguments, verify help content is displayed
+  - [x] 8.7 Test error cases: missing file, invalid JSON, bad format string
+  - [x] 8.8 Verify all existing library tests still pass with `dotnet test`


### PR DESCRIPTION
## Summary
- Added samples/simple-build.json sample build definition file with a 5-state machine (step counter 0-3 + done flag)
- Added 14 end-to-end tests in EndToEndTests.cs covering full pipeline: build with all formats, output file creation, export command, help display, and error cases
- Marked all task 8.0 sub-tasks as complete in the task list

## Test plan
- [x] All 726 tests pass with dotnet test
- [x] End-to-end tests exercise build, export, help, and error paths through Program.Run
- [x] Sample definition file produces expected 5-state machine

Generated with [Claude Code](https://claude.com/claude-code)