### PR TITLE
Add console usage documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,18 @@ StateMaker automates the tedious and error-prone process of manually defining al
 3. Configure **exploration limits** (exhaustive or bounded)
 4. Let StateMaker **generate all reachable states** automatically
 
+## Getting Started with the Command Line
+
+The fastest way to use StateMaker is through the command-line tool. Define your states and rules in a JSON file, then run:
+
+```bash
+statemaker build definition.json
+statemaker build definition.json --format dot --output graph.dot
+statemaker export machine.json --format graphml -o machine.graphml
+```
+
+For complete command-line usage, file format reference, and input validation rules, see the **[Console Usage Guide](/docs/statemaker-console-usage.md)**.
+
 ## Key Features
 
 - **Automatic State Discovery**: Generate all reachable states from transformation rules
@@ -85,6 +97,7 @@ var stateMachine = builder.Build(initialState, rules, config);
 ## Project Resources
 
 ### Documentation
+- **[Console Usage Guide](/docs/statemaker-console-usage.md)** - Command-line usage, file formats, and input validation rules
 - **[Developer Documentation](/docs/README.md)** - Architecture guides and design documents
 - **[Declarative Rules Architecture](/docs/architecture/declarative-rules.md)** - How declarative rules work
 - **[Product Requirements Document](/tasks/prd-state-machine-builder.md)** - Complete PRD with requirements, user stories, and technical specifications

--- a/docs/statemaker-console-usage.md
+++ b/docs/statemaker-console-usage.md
@@ -1,0 +1,300 @@
+# StateMaker Console Usage
+
+StateMaker is a command-line tool that builds state machines from JSON definition files and exports them to multiple output formats.
+
+## Commands
+
+### `build`
+
+Builds a state machine from a build definition file.
+
+```
+statemaker build <definition-file> [options]
+```
+
+| Option | Short | Description | Default |
+|--------|-------|-------------|---------|
+| `--format` | `-f` | Output format: `json`, `dot`, `graphml` | `json` |
+| `--output` | `-o` | Output file path | stdout |
+
+**Examples:**
+
+```
+statemaker build definition.json
+statemaker build definition.json --format dot
+statemaker build definition.json -f graphml -o machine.graphml
+statemaker build definition.json --format dot --output graph.dot
+```
+
+### `export`
+
+Loads a previously built JSON state machine and exports it to another format.
+
+```
+statemaker export <state-machine-file> [options]
+```
+
+| Option | Short | Description | Default |
+|--------|-------|-------------|---------|
+| `--format` | `-f` | Output format: `json`, `dot`, `graphml` | `json` |
+| `--output` | `-o` | Output file path | stdout |
+
+**Examples:**
+
+```
+statemaker export machine.json --format dot
+statemaker export machine.json -f graphml -o machine.graphml
+```
+
+### No arguments
+
+Running `statemaker` with no arguments displays help text showing available commands and options.
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Success |
+| `1` | Error (message and stack trace printed to stderr) |
+
+## Build Definition File Format
+
+The `build` command takes a JSON build definition file with three sections: `initialState`, `rules`, and an optional `config`.
+
+### Sample Definition File
+
+```json
+{
+  "initialState": {
+    "step": 0,
+    "done": false
+  },
+  "rules": [
+    {
+      "name": "Advance",
+      "condition": "step < 3",
+      "transformations": {
+        "step": "step + 1"
+      }
+    },
+    {
+      "name": "Finish",
+      "condition": "step == 3 && done == false",
+      "transformations": {
+        "done": "true"
+      }
+    }
+  ],
+  "config": {
+    "maxStates": 20,
+    "explorationStrategy": "BreadthFirstSearch"
+  }
+}
+```
+
+### `initialState` (required)
+
+An object defining the starting state variables and their initial values. Each property becomes a variable in the state machine's initial state.
+
+Supported value types:
+- **Integer**: `0`, `1`, `42`
+- **Double**: `3.14`, `0.5`
+- **Boolean**: `true`, `false`
+- **String**: `"active"`, `"idle"`
+- **Null**: `null`
+
+```json
+"initialState": {
+  "count": 0,
+  "active": true,
+  "label": "start"
+}
+```
+
+**Validation rules:**
+- Must be present in the definition file.
+- Must not be `null`.
+- Must be a JSON object (not an array or scalar).
+
+### `rules` (required)
+
+An array of rule objects. Each rule defines a condition under which a state transition occurs and the transformations applied to produce the new state. There are two rule types: declarative and custom.
+
+#### Declarative Rules
+
+The default rule type. Uses string expressions for conditions and transformations.
+
+| Property | Required | Description |
+|----------|----------|-------------|
+| `name` | Yes | Display name for the rule, used as the transition label. |
+| `condition` | Yes | A boolean expression evaluated against the current state variables. The rule applies when this evaluates to `true`. |
+| `transformations` | No | An object mapping variable names to expressions that compute new values. |
+| `type` | No | Set to `"declarative"` or omit entirely (declarative is the default). |
+
+```json
+{
+  "name": "Increment",
+  "condition": "count < 5",
+  "transformations": {
+    "count": "count + 1"
+  }
+}
+```
+
+**Validation rules:**
+- `name` is required and must be a string.
+- `condition` is required and must be a string.
+- Transformation values must be string expressions.
+
+#### Custom Rules
+
+Loads a rule implementation from an external .NET assembly.
+
+| Property | Required | Description |
+|----------|----------|-------------|
+| `type` | Yes | Must be `"custom"`. |
+| `assemblyPath` | Yes | File path to the .NET assembly containing the rule class. |
+| `className` | Yes | Fully qualified class name implementing `IRule`. |
+
+```json
+{
+  "type": "custom",
+  "assemblyPath": "path/to/MyRules.dll",
+  "className": "MyNamespace.MyCustomRule"
+}
+```
+
+**Validation rules:**
+- `assemblyPath` is required and the assembly file must exist and be loadable.
+- `className` is required, must exist in the assembly, must implement `IRule`, and must have a parameterless constructor.
+
+### `config` (optional)
+
+Configuration settings for the state machine builder. All properties are optional; defaults are used when omitted.
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `maxStates` | integer | unlimited | Maximum number of states to generate. Stops exploration when reached. |
+| `maxDepth` | integer | unlimited | Maximum depth of exploration from the initial state. |
+| `explorationStrategy` | string | `"BreadthFirstSearch"` | Strategy for exploring the state space. |
+
+Supported `explorationStrategy` values:
+- `"BreadthFirstSearch"` - Explores states level by level.
+- `"DepthFirstSearch"` - Explores states by following each path to its end before backtracking.
+
+```json
+"config": {
+  "maxStates": 100,
+  "maxDepth": 10,
+  "explorationStrategy": "DepthFirstSearch"
+}
+```
+
+**Validation rules:**
+- `explorationStrategy` must be exactly `"BreadthFirstSearch"` or `"DepthFirstSearch"` (case-sensitive). Any other value produces an error.
+- `maxStates` and `maxDepth` must be valid integers.
+
+### Expression Syntax
+
+Conditions and transformations use the [NCalc](https://github.com/ncalc/ncalc) expression language. Expressions can reference state variables by name.
+
+**Supported operators:**
+
+| Category | Operators |
+|----------|-----------|
+| Arithmetic | `+`, `-`, `*`, `/`, `%` |
+| Comparison | `==`, `!=`, `<`, `>`, `<=`, `>=` |
+| Logical | `&&`, `\|\|`, `!` |
+
+**Examples:**
+
+```
+step + 1
+count < 10
+active == true && retries < 3
+score * 2 + bonus
+```
+
+**Validation rules:**
+- Expressions must use valid syntax. Invalid syntax produces an error.
+- All variables referenced in an expression must exist in the current state. Referencing an undefined variable produces an error.
+- Condition expressions must evaluate to a boolean value.
+- Division by zero produces an error.
+
+## Output Formats
+
+### JSON (`--format json`)
+
+The default output format. Produces a JSON object representing the complete state machine with states, transitions, and a starting state identifier.
+
+```json
+{
+  "startingStateId": "S0",
+  "states": {
+    "S0": {
+      "step": 0,
+      "done": false
+    },
+    "S1": {
+      "step": 1,
+      "done": false
+    }
+  },
+  "transitions": [
+    {
+      "sourceStateId": "S0",
+      "targetStateId": "S1",
+      "ruleName": "Advance"
+    }
+  ]
+}
+```
+
+| Property | Description |
+|----------|-------------|
+| `startingStateId` | The ID of the initial state. |
+| `states` | An object where each key is a state ID and each value contains the state's variable values. |
+| `transitions` | An array of transitions, each with `sourceStateId`, `targetStateId`, and `ruleName`. |
+
+This format can be used as input to the `export` command.
+
+### DOT (`--format dot`)
+
+Produces a [Graphviz DOT](https://graphviz.org/doc/info/lang.html) directed graph. Nodes represent states with their variable values. Edges represent transitions labeled with the rule name. The starting state is indicated by a point node with an arrow.
+
+```dot
+digraph StateMachine {
+    rankdir=LR;
+    node [shape=box];
+    __start [shape=point, width=0.2, label=""];
+    __start -> "S0";
+    "S0" [label="S0\nstep=0\ndone=false"];
+    "S1" [label="S1\nstep=1\ndone=false"];
+    "S0" -> "S1" [label="Advance"];
+}
+```
+
+Render with Graphviz tools such as `dot -Tpng graph.dot -o graph.png`.
+
+### GraphML (`--format graphml`)
+
+Produces [GraphML](http://graphml.graphdrawing.org/) XML with [yEd](https://www.yworks.com/products/yed) extensions for visual styling. Nodes include shape, color, and label data. The starting state node is highlighted with a green fill and thicker border.
+
+This format can be opened directly in yEd for interactive viewing and layout.
+
+## Error Cases
+
+| Scenario | Behavior |
+|----------|----------|
+| Missing file path argument for `build` or `export` | Error message to stderr, exit code 1. |
+| Definition or state machine file not found | `"not found"` message to stderr, exit code 1. |
+| Invalid JSON in input file | Parse error details to stderr, exit code 1. |
+| Missing required `initialState` section | Error message to stderr, exit code 1. |
+| Missing required `rules` section | Error message to stderr, exit code 1. |
+| Unsupported `--format` value | Error listing supported formats to stderr, exit code 1. |
+| Unknown command | `"Unknown command"` message and help text to stderr, exit code 1. |
+| Invalid expression syntax in a rule | Error message with expression details to stderr, exit code 1. |
+| Undefined variable referenced in expression | Error message with expression and variable details to stderr, exit code 1. |
+| Unknown exploration strategy | Error listing supported strategies to stderr, exit code 1. |
+
+All errors print the exception message and full stack trace to stderr and return exit code 1.


### PR DESCRIPTION
## Summary
- Added docs/statemaker-console-usage.md with complete command-line reference: commands, switches, build definition file format with samples, expression syntax, output format descriptions, and input validation rules
- Added prominent "Getting Started with the Command Line" section to README with quick examples and link to the full guide
- Listed Console Usage Guide first in the README documentation links

## Test plan
- [x] Verify markdown renders correctly
- [x] Verify all links point to correct files

Generated with [Claude Code](https://claude.com/claude-code)