### PR TITLE
Fix DOT newline escaping, expression error message, and docs

### DIFF
--- a/docs/architecture/expression-evaluation.md
+++ b/docs/architecture/expression-evaluation.md
@@ -52,11 +52,13 @@ Used in `Execute()` to compute new variable values.
 
 | Expression | State Variables | Result |
 |---|---|---|
-| `"Approved"` | (any) | `"Approved"` (literal) |
+| `'Approved'` | (any) | `"Approved"` (string literal) |
 | `Count + 1` | `{ Count: 5 }` | `6` |
 | `Amount * 0.9` | `{ Amount: 100 }` | `90.0` |
 | `true` | (any) | `true` (literal) |
 | `(Price * Quantity) - Discount` | `{ Price: 10, Quantity: 3, Discount: 5 }` | `25` |
+
+**Important:** String literals in expressions must use **single quotes** (`'Approved'`). Unquoted text like `Approved` is interpreted as a variable name reference, which will cause an error if no variable with that name exists in the state.
 
 ## Supported Operators
 
@@ -82,7 +84,7 @@ The expression evaluator supports the following operators via NCalc:
 - Parenthetical expressions: `(Amount + Tax) * Rate`
 
 **Literal Values:**
-- Strings: `'Pending'`, `"Approved"`
+- Strings: `'Pending'`, `'Approved'` (must use single quotes)
 - Integers: `42`, `0`, `-1`
 - Booleans: `true`, `false`
 - Floats: `3.14`, `0.5`
@@ -171,7 +173,7 @@ All errors are thrown as `InvalidOperationException` with descriptive messages:
 
 | Error | Message Pattern |
 |---|---|
-| Undefined variable | `"Variable not found in state. Expression: '{expr}'. Detail: {message}"` |
+| Undefined parameter | `"Undefined parameter in expression '{expr}'. If you intended a string literal, wrap it in single quotes (e.g. 'value' instead of value). Detail: {message}"` |
 | Non-boolean condition | `"Expression '{expr}' did not evaluate to a boolean value. Got: {type}"` |
 | Division by zero | `"Division by zero in expression '{expr}'"` |
 | Invalid syntax | `"Invalid expression syntax: {details}"` |

--- a/docs/statemaker-console-usage.md
+++ b/docs/statemaker-console-usage.md
@@ -9,7 +9,7 @@ StateMaker is a command-line tool that builds state machines from JSON definitio
 Builds a state machine from a build definition file.
 
 ```
-statemaker build <definition-file> [options]
+statemaker.console build <definition-file> [options]
 ```
 
 | Option | Short | Description | Default |
@@ -20,10 +20,10 @@ statemaker build <definition-file> [options]
 **Examples:**
 
 ```
-statemaker build definition.json
-statemaker build definition.json --format dot
-statemaker build definition.json -f graphml -o machine.graphml
-statemaker build definition.json --format dot --output graph.dot
+statemaker.console build definition.json
+statemaker.console build definition.json --format dot
+statemaker.console build definition.json -f graphml -o machine.graphml
+statemaker.console build definition.json --format dot --output graph.dot
 ```
 
 ### `export`
@@ -31,7 +31,7 @@ statemaker build definition.json --format dot --output graph.dot
 Loads a previously built JSON state machine and exports it to another format.
 
 ```
-statemaker export <state-machine-file> [options]
+statemaker.console export <state-machine-file> [options]
 ```
 
 | Option | Short | Description | Default |
@@ -42,13 +42,13 @@ statemaker export <state-machine-file> [options]
 **Examples:**
 
 ```
-statemaker export machine.json --format dot
-statemaker export machine.json -f graphml -o machine.graphml
+statemaker.console export machine.json --format dot
+statemaker.console export machine.json -f graphml -o machine.graphml
 ```
 
 ### No arguments
 
-Running `statemaker` with no arguments displays help text showing available commands and options.
+Running `statemaker.console` with no arguments displays help text showing available commands and options.
 
 ## Exit Codes
 
@@ -206,6 +206,17 @@ Conditions and transformations use the [NCalc](https://github.com/ncalc/ncalc) e
 | Comparison | `==`, `!=`, `<`, `>`, `<=`, `>=` |
 | Logical | `&&`, `\|\|`, `!` |
 
+**Literal values:**
+
+| Type | Syntax | Example |
+|------|--------|---------|
+| String | Single quotes | `'Approved'`, `'idle'` |
+| Integer | Numeric | `0`, `42`, `-1` |
+| Double | Decimal | `3.14`, `0.5` |
+| Boolean | `true` / `false` | `true` |
+
+String literals **must** use single quotes. Unquoted text is interpreted as a variable name reference.
+
 **Examples:**
 
 ```
@@ -213,7 +224,24 @@ step + 1
 count < 10
 active == true && retries < 3
 score * 2 + bonus
+'Approved'
 ```
+
+**String transformation example:**
+
+To set a variable to a string value, wrap the value in single quotes:
+
+```json
+{
+  "name": "Approve",
+  "condition": "Status == 'Pending'",
+  "transformations": {
+    "Status": "'Approved'"
+  }
+}
+```
+
+Without single quotes, `"Status": "Approved"` would be interpreted as a reference to a variable named `Approved`, not the string value.
 
 **Validation rules:**
 - Expressions must use valid syntax. Invalid syntax produces an error.

--- a/src/StateMaker/DotExporter.cs
+++ b/src/StateMaker/DotExporter.cs
@@ -27,7 +27,7 @@ public class DotExporter : IStateMachineExporter
         {
             var label = BuildNodeLabel(kvp.Key, kvp.Value);
             sb.AppendLine(CultureInfo.InvariantCulture,
-                $"    \"{EscapeDot(kvp.Key)}\" [label=\"{EscapeDot(label)}\"];");
+                $"    \"{EscapeDot(kvp.Key)}\" [label=\"{label}\"];");
         }
 
         // Edges
@@ -43,17 +43,13 @@ public class DotExporter : IStateMachineExporter
 
     private static string BuildNodeLabel(string stateId, State state)
     {
-        var sb = new StringBuilder();
-        sb.Append(stateId);
-        if (state.Variables.Count > 0)
+        var parts = new List<string>();
+        parts.Add(EscapeDot(stateId));
+        foreach (var kvp in state.Variables)
         {
-            sb.Append("\\n");
-            foreach (var kvp in state.Variables)
-            {
-                sb.Append(CultureInfo.InvariantCulture, $"{kvp.Key}={FormatValue(kvp.Value)}\\n");
-            }
+            parts.Add($"{EscapeDot(kvp.Key)}={EscapeDot(FormatValue(kvp.Value))}");
         }
-        return sb.ToString().TrimEnd('\\', 'n');
+        return string.Join("\\n", parts);
     }
 
     private static string FormatValue(object? value)

--- a/src/StateMaker/ExpressionEvaluator.cs
+++ b/src/StateMaker/ExpressionEvaluator.cs
@@ -64,13 +64,14 @@ public class ExpressionEvaluator : IExpressionEvaluator
             throw new InvalidOperationException(
                 $"Division by zero in expression '{expression}'");
         }
-        catch (Exception ex) when (ex.Message.Contains("not found", StringComparison.OrdinalIgnoreCase)
-                                   || ex.Message.Contains("parameter", StringComparison.OrdinalIgnoreCase))
+        catch (Exception ex) when (ex.Message.Contains("not defined", StringComparison.OrdinalIgnoreCase)
+                                   || ex.Message.Contains("not found", StringComparison.OrdinalIgnoreCase))
         {
-            // NCalc throws when a parameter referenced in the expression is not in Parameters dict
-            // Extract the variable name from the message if possible
+            // NCalc throws when a parameter referenced in the expression is not in Parameters dict.
+            // This commonly happens when a user writes a string literal without single quotes,
+            // e.g. "activity": "jumping" instead of "activity": "'jumping'"
             throw new InvalidOperationException(
-                $"Variable not found in state. Expression: '{expression}'. Detail: {ex.Message}", ex);
+                $"Undefined parameter in expression '{expression}'. If you intended a string literal, wrap it in single quotes (e.g. 'value' instead of value). Detail: {ex.Message}", ex);
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Summary
- **DOT export bug fix**: DotExporter.BuildNodeLabel assembled labels with literal backslash-n sequences, then EscapeDot() double-escaped the backslashes, causing GraphViz to render literal text instead of actual newlines. Fixed by escaping individual components before joining with newline separators.
- **Expression error message improvement**: When an unquoted string like jumping is used in a transformation expression, NCalc throws a parameter not defined error. The old error message (Variable not found in state) was misleading. The new message suggests wrapping string literals in single quotes.
- **Documentation fixes**: Corrected executable name from statemaker to statemaker.console throughout console usage docs. Added string literal syntax documentation (single quotes required) to both console usage and expression evaluation architecture docs.

## Test plan
- [x] All 726 existing tests pass
- [ ] Verify DOT export renders newlines correctly in GraphViz
- [ ] Verify expression error message is helpful for unquoted string literals

Generated with [Claude Code](https://claude.com/claude-code)