### PR TITLE
Add custom exceptions for JSON and expression errors

### DIFF
--- a/src/StateMaker.Tests/BuildDefinitionLoaderTests.cs
+++ b/src/StateMaker.Tests/BuildDefinitionLoaderTests.cs
@@ -19,7 +19,7 @@ public class BuildDefinitionLoaderTests
     {
         var loader = new BuildDefinitionLoader();
 
-        Assert.Throws<InvalidOperationException>(() => loader.LoadFromJson("not valid json"));
+        Assert.Throws<JsonParseException>(() => loader.LoadFromJson("not valid json"));
     }
 
     [Fact]

--- a/src/StateMaker.Tests/DeclarativeRuleTests.cs
+++ b/src/StateMaker.Tests/DeclarativeRuleTests.cs
@@ -234,7 +234,7 @@ public class DeclarativeRuleTests
             Transforms(("x", "=== invalid ===")), _evaluator);
         var state = MakeState(("x", 1));
 
-        Assert.Throws<InvalidOperationException>(() => rule.Execute(state));
+        Assert.Throws<ExpressionEvaluationException>(() => rule.Execute(state));
     }
 
     [Fact]
@@ -244,7 +244,7 @@ public class DeclarativeRuleTests
             Transforms(), _evaluator);
         var state = MakeState(("x", 1));
 
-        Assert.Throws<InvalidOperationException>(() => rule.IsAvailable(state));
+        Assert.Throws<ExpressionEvaluationException>(() => rule.IsAvailable(state));
     }
 
     #endregion

--- a/src/StateMaker.Tests/ExporterTests.cs
+++ b/src/StateMaker.Tests/ExporterTests.cs
@@ -193,7 +193,7 @@ public class ExporterTests
     [Fact]
     public void JsonImporter_InvalidJson_Throws()
     {
-        Assert.Throws<InvalidOperationException>(() =>
+        Assert.Throws<JsonParseException>(() =>
             new JsonImporter().Import("not json {{{"));
     }
 

--- a/src/StateMaker.Tests/ExpressionEvaluatorTests.cs
+++ b/src/StateMaker.Tests/ExpressionEvaluatorTests.cs
@@ -324,7 +324,7 @@ public class ExpressionEvaluatorTests
     [Fact]
     public void Evaluate_UndefinedVariable_Throws()
     {
-        var ex = Assert.Throws<InvalidOperationException>(() =>
+        var ex = Assert.Throws<ExpressionEvaluationException>(() =>
             _evaluator.Evaluate("[MissingVar] + 1", Vars(("Other", 5))));
         Assert.Contains("MissingVar", ex.Message, StringComparison.Ordinal);
     }
@@ -332,7 +332,7 @@ public class ExpressionEvaluatorTests
     [Fact]
     public void EvaluateBoolean_UndefinedVariable_Throws()
     {
-        var ex = Assert.Throws<InvalidOperationException>(() =>
+        var ex = Assert.Throws<ExpressionEvaluationException>(() =>
             _evaluator.EvaluateBoolean("[Missing] == true", Vars()));
         Assert.Contains("Missing", ex.Message, StringComparison.Ordinal);
     }
@@ -340,7 +340,7 @@ public class ExpressionEvaluatorTests
     [Fact]
     public void Evaluate_InvalidSyntax_Throws()
     {
-        var ex = Assert.Throws<InvalidOperationException>(() =>
+        var ex = Assert.Throws<ExpressionEvaluationException>(() =>
             _evaluator.Evaluate("=== invalid ===", Vars()));
         Assert.Contains("syntax", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
@@ -348,7 +348,7 @@ public class ExpressionEvaluatorTests
     [Fact]
     public void Evaluate_DivisionByZero_Throws()
     {
-        var ex = Assert.Throws<InvalidOperationException>(() =>
+        var ex = Assert.Throws<ExpressionEvaluationException>(() =>
             _evaluator.Evaluate("[x] / 0", Vars(("x", 10))));
         Assert.Contains("Division by zero", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
@@ -356,9 +356,9 @@ public class ExpressionEvaluatorTests
     [Fact]
     public void EvaluateBoolean_NonBooleanExpression_Throws()
     {
-        var ex = Assert.Throws<InvalidOperationException>(() =>
+        var ex = Assert.Throws<ExpressionEvaluationException>(() =>
             _evaluator.EvaluateBoolean("[x] + 1", Vars(("x", 5))));
-        Assert.Contains("did not evaluate to a boolean", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("Expected a boolean result", ex.Message, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -378,7 +378,7 @@ public class ExpressionEvaluatorTests
     [Fact]
     public void Evaluate_EmptyExpression_Throws()
     {
-        Assert.Throws<InvalidOperationException>(() =>
+        Assert.Throws<ExpressionEvaluationException>(() =>
             _evaluator.Evaluate("", Vars()));
     }
 
@@ -392,14 +392,14 @@ public class ExpressionEvaluatorTests
         // NCalc only evaluates mathematical/logical expressions
         // It cannot call .NET methods, access files, or make network calls.
         // This test verifies that function-like syntax fails (no custom functions registered).
-        Assert.Throws<InvalidOperationException>(() =>
+        Assert.Throws<ExpressionEvaluationException>(() =>
             _evaluator.Evaluate("System.IO.File.ReadAllText('test.txt')", Vars()));
     }
 
     [Fact]
     public void Evaluate_NoReflection()
     {
-        Assert.Throws<InvalidOperationException>(() =>
+        Assert.Throws<ExpressionEvaluationException>(() =>
             _evaluator.Evaluate("GetType().Assembly", Vars()));
     }
 

--- a/src/StateMaker.Tests/RuleFileLoaderTests.cs
+++ b/src/StateMaker.Tests/RuleFileLoaderTests.cs
@@ -242,7 +242,7 @@ public class RuleFileLoaderTests
     [Fact]
     public void LoadFromJson_InvalidJson_Throws()
     {
-        var ex = Assert.Throws<InvalidOperationException>(() =>
+        var ex = Assert.Throws<JsonParseException>(() =>
             _loader.LoadFromJson("not valid json {{{"));
         Assert.Contains("JSON", ex.Message, StringComparison.OrdinalIgnoreCase);
     }

--- a/src/StateMaker/BuildDefinitionLoader.cs
+++ b/src/StateMaker/BuildDefinitionLoader.cs
@@ -24,7 +24,7 @@ public class BuildDefinitionLoader
         }
         catch (JsonException ex)
         {
-            throw new InvalidOperationException($"Invalid JSON syntax: {ex.Message}", ex);
+            throw new JsonParseException(ex);
         }
 
         var root = doc.RootElement;

--- a/src/StateMaker/ExpressionEvaluationException.cs
+++ b/src/StateMaker/ExpressionEvaluationException.cs
@@ -1,0 +1,18 @@
+namespace StateMaker;
+
+public class ExpressionEvaluationException : Exception
+{
+    public string Expression { get; }
+
+    public ExpressionEvaluationException(string expression, string reason)
+        : base($"Error in expression '{expression}': {reason}")
+    {
+        Expression = expression;
+    }
+
+    public ExpressionEvaluationException(string expression, string reason, Exception innerException)
+        : base($"Error in expression '{expression}': {reason}", innerException)
+    {
+        Expression = expression;
+    }
+}

--- a/src/StateMaker/JsonImporter.cs
+++ b/src/StateMaker/JsonImporter.cs
@@ -15,7 +15,7 @@ public class JsonImporter : IStateMachineImporter
         }
         catch (JsonException ex)
         {
-            throw new InvalidOperationException($"Invalid JSON syntax: {ex.Message}", ex);
+            throw new JsonParseException(ex);
         }
 
         var root = doc.RootElement;

--- a/src/StateMaker/JsonParseException.cs
+++ b/src/StateMaker/JsonParseException.cs
@@ -1,0 +1,43 @@
+using System.Text.Json;
+
+namespace StateMaker;
+
+public class JsonParseException : Exception
+{
+    public long? LineNumber { get; }
+    public long? Position { get; }
+
+    public JsonParseException(JsonException innerException)
+        : base(FormatMessage(innerException), innerException)
+    {
+        LineNumber = innerException.LineNumber.HasValue ? innerException.LineNumber.Value + 1 : null;
+        Position = innerException.BytePositionInLine;
+    }
+
+    private static string FormatMessage(JsonException ex)
+    {
+        var description = ex.Message;
+
+        // Strip internal System.Text.Json guidance like "Change the reader options."
+        var changeIndex = description.IndexOf("Change the reader options.", StringComparison.OrdinalIgnoreCase);
+        if (changeIndex > 0)
+        {
+            description = description[..changeIndex].TrimEnd();
+        }
+
+        // Strip the appended "LineNumber: X | BytePositionInLine: Y." since
+        // we reconstruct location from the structured properties
+        var lineNumberIndex = description.IndexOf("LineNumber:", StringComparison.OrdinalIgnoreCase);
+        if (lineNumberIndex > 0)
+        {
+            description = description[..lineNumberIndex].TrimEnd();
+        }
+
+        if (ex.LineNumber.HasValue)
+        {
+            return $"Invalid JSON at line {ex.LineNumber.Value + 1}, position {ex.BytePositionInLine}: {description}";
+        }
+
+        return $"Invalid JSON: {description}";
+    }
+}

--- a/src/StateMaker/RuleFileLoader.cs
+++ b/src/StateMaker/RuleFileLoader.cs
@@ -33,7 +33,7 @@ public class RuleFileLoader
         }
         catch (JsonException ex)
         {
-            throw new InvalidOperationException($"Invalid JSON syntax: {ex.Message}", ex);
+            throw new JsonParseException(ex);
         }
 
         var root = doc.RootElement;


### PR DESCRIPTION
## Summary
- **JsonParseException**: Replaces InvalidOperationException for JSON parse failures. Strips internal System.Text.Json text like "Change the reader options" and formats clean line/position info. Applied in BuildDefinitionLoader, RuleFileLoader, and JsonImporter.
- **ExpressionEvaluationException**: Replaces InvalidOperationException for all expression evaluation failures. Provides clean messages for syntax errors, undefined parameters (with single-quote hint), division by zero, and non-boolean results. NCalc exceptions are preserved as inner exceptions. Includes an Expression property for programmatic access.
- Both follow the same pattern as the existing StateDoesNotExistException.

## Test plan
- [x] All 726 existing tests pass (updated to assert new exception types)
- [ ] Verify trailing comma JSON error shows clean message
- [ ] Verify bad expression syntax error shows clean message
- [ ] Verify unquoted string literal error shows single-quote hint

Generated with [Claude Code](https://claude.com/claude-code)