### PR TITLE
Add Mermaid flowchart export format

### DIFF
--- a/docs/architecture/export-formats.md
+++ b/docs/architecture/export-formats.md
@@ -288,19 +288,72 @@ Each transition is an `<edge>` element with line styling and an edge label:
 4. The graph renders with all states, variables, and transitions visible
 5. Use yEd's layout algorithms to arrange the graph
 
+## Mermaid Format
+
+### Purpose
+- Text-based diagram syntax rendered by Mermaid.js
+- Native support in GitHub markdown, GitLab, Notion, and many documentation tools
+- No external tools needed — renders directly in browsers
+- Good for embedding state machine diagrams in documentation and README files
+
+### Target Tools
+- **GitHub**: Renders Mermaid in markdown files and PR descriptions
+- **Mermaid Live Editor**: https://mermaid.live
+- **IDE extensions**: Mermaid Preview for VSCode
+- **Documentation tools**: Docusaurus, MkDocs, Notion
+
+### Structure
+
+```mermaid
+flowchart TD
+    S0["S0<br />OrderStatus='Pending'<br />Amount=500<br />IsApproved=false"]
+    S1["S1<br />OrderStatus='Approved'<br />Amount=500<br />IsApproved=true"]
+    S2["S2<br />OrderStatus='Rejected'<br />Amount=500<br />IsApproved=false"]
+    _start_((" ")) --> S0
+    style _start_ fill:#000,stroke:#000,color:#000
+    S0 -->|ApproveOrder| S1
+    S0 -->|RejectOrder| S2
+    S2 -->|RetryOrder| S0
+```
+
+### State Representation in Mermaid
+
+States are defined as flowchart nodes with a quoted label containing the state ID followed by variable name/value pairs separated by `<br />`. HTML entities are used to escape `<`, `>`, and `&` in values:
+
+```
+S0["S0<br />OrderStatus='Pending'<br />Amount=500"]
+```
+
+### Transition Representation in Mermaid
+
+Transitions use the `-->` arrow with a pipe-delimited label:
+
+```
+S0 -->|ApproveOrder| S1
+```
+
+### Starting State Indicator
+
+The starting state is indicated using a filled circle node:
+
+```
+_start_((" ")) --> S0
+style _start_ fill:#000,stroke:#000,color:#000
+```
+
 ## Format Comparison
 
-| Feature | JSON | DOT | GraphML |
-|---|---|---|---|
-| Human readable | Moderate | High | Low (XML) |
-| Machine readable | High | Low | Moderate |
-| Round-trip import | Yes | No | No |
-| Visualization | Via JSON viewers | Graphviz | yEd |
-| State variables | Key-value pairs | Node labels | Node labels |
-| Transition labels | Rule name field | Edge labels | Edge labels |
-| Visual styling | None | Basic | Rich |
-| File size | Small | Small | Large (XML overhead) |
-| Version control | Good (diffable) | Good (diffable) | Poor (XML noise) |
+| Feature | JSON | DOT | GraphML | Mermaid |
+|---|---|---|---|---|
+| Human readable | Moderate | High | Low (XML) | High |
+| Machine readable | High | Low | Moderate | Moderate |
+| Round-trip import | Yes | No | No | No |
+| Visualization | Via JSON viewers | Graphviz | yEd | Mermaid.js / GitHub |
+| State variables | Key-value pairs | Node labels | Node labels | State labels |
+| Transition labels | Rule name field | Edge labels | Edge labels | Edge labels |
+| Visual styling | None | Basic | Rich | Basic |
+| File size | Small | Small | Large (XML overhead) | Small |
+| Version control | Good (diffable) | Good (diffable) | Poor (XML noise) | Good (diffable) |
 
 ## Implementation Notes
 
@@ -315,6 +368,7 @@ public interface IStateMachineExporter
 public class JsonExporter : IStateMachineExporter { ... }
 public class DotExporter : IStateMachineExporter { ... }
 public class GraphMlExporter : IStateMachineExporter { ... }
+public class MermaidExporter : IStateMachineExporter { ... }
 ```
 
 ### Import Interface
@@ -328,11 +382,11 @@ public interface IStateMachineImporter
 public class JsonImporter : IStateMachineImporter { ... }
 ```
 
-Only JSON import is supported. DOT and GraphML are export-only formats.
+Only JSON import is supported. DOT, GraphML, and Mermaid are export-only formats.
 
 ### Node Label Generation
 
-For both DOT and GraphML, state labels are generated from the state ID followed by variable key=value pairs. Values are formatted by type: strings in single quotes, booleans as `true`/`false`, nulls as `null`, and numbers as-is.
+For DOT, GraphML, and Mermaid, state labels are generated from the state ID followed by variable key=value pairs. Values are formatted by type: strings in single quotes, booleans as `true`/`false`, nulls as `null`, and numbers as-is.
 
 Variables appear in dictionary iteration order (insertion order). They are not sorted alphabetically.
 

--- a/docs/statemaker-console-usage.md
+++ b/docs/statemaker-console-usage.md
@@ -14,7 +14,7 @@ statemaker.console build <definition-file> [options]
 
 | Option | Short | Description | Default |
 |--------|-------|-------------|---------|
-| `--format` | `-f` | Output format: `json`, `dot`, `graphml` | `json` |
+| `--format` | `-f` | Output format: `json`, `dot`, `graphml`, `mermaid` | `json` |
 | `--output` | `-o` | Output file path | stdout |
 
 **Examples:**
@@ -36,7 +36,7 @@ statemaker.console export <state-machine-file> [options]
 
 | Option | Short | Description | Default |
 |--------|-------|-------------|---------|
-| `--format` | `-f` | Output format: `json`, `dot`, `graphml` | `json` |
+| `--format` | `-f` | Output format: `json`, `dot`, `graphml`, `mermaid` | `json` |
 | `--output` | `-o` | Output file path | stdout |
 
 **Examples:**
@@ -309,6 +309,21 @@ Render with Graphviz tools such as `dot -Tpng graph.dot -o graph.png`.
 Produces [GraphML](http://graphml.graphdrawing.org/) XML with [yEd](https://www.yworks.com/products/yed) extensions for visual styling. Nodes include shape, color, and label data. The starting state node is highlighted with a green fill and thicker border.
 
 This format can be opened directly in yEd for interactive viewing and layout.
+
+### Mermaid (`--format mermaid`)
+
+Produces a [Mermaid](https://mermaid.js.org/) flowchart diagram. States include their variable values as labels. Transitions are labeled with the rule name. The starting state is indicated with a filled circle node.
+
+```mermaid
+flowchart TD
+    S0["S0<br />step=0<br />done=false"]
+    S1["S1<br />step=1<br />done=false"]
+    _start_((" ")) --> S0
+    style _start_ fill:#000,stroke:#000,color:#000
+    S0 -->|Advance| S1
+```
+
+Mermaid diagrams render natively in GitHub markdown, GitLab, and the [Mermaid Live Editor](https://mermaid.live).
 
 ## Error Cases
 

--- a/src/StateMaker.Tests/ExporterFactoryTests.cs
+++ b/src/StateMaker.Tests/ExporterFactoryTests.cs
@@ -29,6 +29,22 @@ public class ExporterFactoryTests
     }
 
     [Fact]
+    public void GetExporter_Mermaid_ReturnsMermaidExporter()
+    {
+        var exporter = ExporterFactory.GetExporter("mermaid");
+
+        Assert.IsType<MermaidExporter>(exporter);
+    }
+
+    [Fact]
+    public void GetExporter_CaseInsensitive_Mermaid()
+    {
+        var exporter = ExporterFactory.GetExporter("MERMAID");
+
+        Assert.IsType<MermaidExporter>(exporter);
+    }
+
+    [Fact]
     public void GetExporter_CaseInsensitive_Json()
     {
         var exporter = ExporterFactory.GetExporter("JSON");

--- a/src/StateMaker.Tests/ExporterTests.cs
+++ b/src/StateMaker.Tests/ExporterTests.cs
@@ -427,6 +427,67 @@ public class ExporterTests
 
     #endregion
 
+    #region MermaidExporter
+
+    [Fact]
+    public void MermaidExporter_ProducesValidMermaidSyntax()
+    {
+        var machine = BuildSimpleMachine();
+        var mermaid = new MermaidExporter().Export(machine);
+        Assert.StartsWith("flowchart TD", mermaid, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MermaidExporter_ContainsAllStates()
+    {
+        var machine = BuildSimpleMachine();
+        var mermaid = new MermaidExporter().Export(machine);
+        Assert.Contains("S0", mermaid, StringComparison.Ordinal);
+        Assert.Contains("S1", mermaid, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MermaidExporter_ContainsAllTransitions()
+    {
+        var machine = BuildSimpleMachine();
+        var mermaid = new MermaidExporter().Export(machine);
+        Assert.Contains("S0 -->|Approve| S1", mermaid, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MermaidExporter_ContainsStartingStateIndicator()
+    {
+        var machine = BuildSimpleMachine();
+        var mermaid = new MermaidExporter().Export(machine);
+        Assert.Contains("_start_", mermaid, StringComparison.Ordinal);
+        Assert.Contains("--> S0", mermaid, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MermaidExporter_NodeLabelsIncludeVariables()
+    {
+        var machine = BuildSimpleMachine();
+        var mermaid = new MermaidExporter().Export(machine);
+        Assert.Contains("Status", mermaid, StringComparison.Ordinal);
+        Assert.Contains("Pending", mermaid, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MermaidExporter_CycleMachine_ContainsBackEdge()
+    {
+        var machine = BuildCycleMachine();
+        var mermaid = new MermaidExporter().Export(machine);
+        Assert.Contains("S1 -->|Reset| S0", mermaid, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MermaidExporter_NullStateMachine_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => new MermaidExporter().Export(null!));
+    }
+
+    #endregion
+
     #region 7.10 — Import-Then-Re-Export
 
     [Fact]
@@ -455,6 +516,21 @@ public class ExporterTests
         Assert.Contains("S1", graphml, StringComparison.Ordinal);
         Assert.Contains("Approve", graphml, StringComparison.Ordinal);
         Assert.Contains("ShapeNode", graphml, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ImportThenReExport_JsonToMermaid_ContainsAllData()
+    {
+        var original = BuildSimpleMachine();
+        var json = new JsonExporter().Export(original);
+        var imported = new JsonImporter().Import(json);
+        var mermaid = new MermaidExporter().Export(imported);
+
+        Assert.Contains("S0", mermaid, StringComparison.Ordinal);
+        Assert.Contains("S1", mermaid, StringComparison.Ordinal);
+        Assert.Contains("Approve", mermaid, StringComparison.Ordinal);
+        Assert.Contains("_start_", mermaid, StringComparison.Ordinal);
+        Assert.Contains("--> S0", mermaid, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/src/StateMaker/ExporterFactory.cs
+++ b/src/StateMaker/ExporterFactory.cs
@@ -11,8 +11,9 @@ public static class ExporterFactory
             "JSON" => new JsonExporter(),
             "DOT" => new DotExporter(),
             "GRAPHML" => new GraphMlExporter(),
+            "MERMAID" => new MermaidExporter(),
             _ => throw new ArgumentException(
-                $"Unsupported export format '{format}'. Supported formats: json, dot, graphml.", nameof(format))
+                $"Unsupported export format '{format}'. Supported formats: json, dot, graphml, mermaid.", nameof(format))
         };
     }
 }

--- a/src/StateMaker/MermaidExporter.cs
+++ b/src/StateMaker/MermaidExporter.cs
@@ -1,0 +1,71 @@
+using System.Globalization;
+using System.Text;
+
+namespace StateMaker;
+
+public class MermaidExporter : IStateMachineExporter
+{
+    public string Export(StateMachine stateMachine)
+    {
+        ArgumentNullException.ThrowIfNull(stateMachine);
+
+        var sb = new StringBuilder();
+        sb.AppendLine("flowchart TD");
+
+        // State definitions with labels
+        foreach (var kvp in stateMachine.States)
+        {
+            var label = BuildStateLabel(kvp.Key, kvp.Value);
+            sb.AppendLine(CultureInfo.InvariantCulture,
+                $"    {kvp.Key}[\"{label}\"]");
+        }
+
+        // Starting state indicator
+        if (stateMachine.StartingStateId is not null)
+        {
+            sb.AppendLine(CultureInfo.InvariantCulture,
+                $"    _start_((\" \")) --> {stateMachine.StartingStateId}");
+            sb.AppendLine("    style _start_ fill:#000,stroke:#000,color:#000");
+        }
+
+        // Transitions
+        foreach (var transition in stateMachine.Transitions)
+        {
+            sb.AppendLine(CultureInfo.InvariantCulture,
+                $"    {transition.SourceStateId} -->|{transition.RuleName}| {transition.TargetStateId}");
+        }
+
+        return sb.ToString();
+    }
+
+    private static string BuildStateLabel(string stateId, State state)
+    {
+        var parts = new List<string>();
+        parts.Add(EscapeHtml(stateId));
+        foreach (var kvp in state.Variables)
+        {
+            parts.Add($"{EscapeHtml(kvp.Key)}={FormatValue(kvp.Value)}");
+        }
+        return string.Join("<br />", parts);
+    }
+
+    private static string FormatValue(object? value)
+    {
+        var raw = value switch
+        {
+            string s => $"'{s}'",
+            bool b => b ? "true" : "false",
+            null => "null",
+            _ => string.Format(CultureInfo.InvariantCulture, "{0}", value)
+        };
+        return EscapeHtml(raw);
+    }
+
+    private static string EscapeHtml(string text)
+    {
+        return text.Replace("&", "&amp;", StringComparison.Ordinal)
+                   .Replace("<", "&lt;", StringComparison.Ordinal)
+                   .Replace(">", "&gt;", StringComparison.Ordinal)
+                   .Replace("\"", "&quot;", StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## Summary
- Add MermaidExporter implementing IStateMachineExporter using Mermaid flowchart TD syntax
- State nodes use quoted labels with line breaks and HTML entity escaping for special characters in values
- Starting state rendered as a filled black circle node
- Transitions use pipe-delimited labels
- Register mermaid format in ExporterFactory (case-insensitive)
- Add 10 new tests (7 MermaidExporter + 1 import-re-export + 2 factory)
- Update architecture and console usage documentation with Mermaid examples

## Test plan
- [x] All 736 tests pass
- [x] Release build succeeds
- [ ] Manual: run statemaker.console build definition.json -f mermaid and verify output renders in GitHub markdown or Mermaid Live Editor

Generated with [Claude Code](https://claude.com/claude-code)