### PR TITLE
Add PRD and task list for state filtering feature

### DIFF
--- a/tasks/prd-state-filtering.md
+++ b/tasks/prd-state-filtering.md
@@ -1,0 +1,140 @@
+# PRD: State Filtering, Selection, and Attribution
+
+## 1. Introduction/Overview
+
+StateMaker builds state machines from declarative rule definitions and exports them to various formats. Currently, there is no way to query, filter, or annotate the states within a built state machine.
+
+State filtering adds the ability to select states from a built state machine based on rule expressions, attach markup attributes to those states, and export a reduced state machine containing only the traversal paths that lead to the selected states. This enables use cases such as identifying high-value usage paths, marking states for visual distinction in exports, and reducing large state machines to focused subsets.
+
+## 2. Goals
+
+1. Provide a rules-based mechanism for selecting states from a built state machine using expression conditions similar to the existing build rule system.
+2. Allow markup attributes to be attached to selected states, stored separately from state machine variables.
+3. Enable export of filtered state machines containing only the paths from the starting state to selected states.
+4. Integrate filtering into the console application as both a standalone `filter` command and a `--filter` option on the existing `export` command.
+
+## 3. User Stories
+
+- **As a business analyst**, I want to define criteria for high-priority features and export a state machine showing only the paths that lead to those features, so I can understand which sequences of actions reach important outcomes.
+- **As a tester**, I want to filter a state machine to states where a specific variable has a certain value, so I can focus test generation on a relevant subset of the system.
+- **As a tester**, I want to find ways where the system might get into undesirable states. I define a criteria for undesirable states and apply it to a pre-built state machine defintion to get a list of the traversal patterns which lead to undesirable states.
+- **As a developer**, I want to attach ranking or category attributes to filtered states, so that exported diagrams visually distinguish those states from others.
+- **As a user**, I want to apply a filter during export from the command line, so I can quickly generate focused diagrams without writing a separate filter definition.
+
+## 4. Functional Requirements
+
+### 4.1 Filter Definition Format
+
+1. Filter definitions must be expressed in a JSON file format similar to build definition rules.
+2. Each filter rule must contain a `condition` field using the same expression syntax as build rules (NCalc expressions).
+3. Filter rule conditions must be evaluated against the variables of each state in the state machine.
+4. A state that satisfies any filter rule condition is considered "selected."
+5. Filter definitions must support multiple filter rules, each with its own condition and optional attribute assignments.
+6. Filters will allow `condition` to refer to the state ID in cases where someone knows specifically which node they wish to filter to.
+
+### 4.2 State Attributes
+
+6. The `State` class must have a separate `Attributes` dictionary (distinct from `Variables`) for storing markup attributes. This property is optional on imported state machine definition files, as it is generally only applied when processing filters..
+7. Filter rules must be able to specify key-value attribute pairs to attach to states that match their condition (e.g., `"attributes": { "ranking": "high" }`).
+8. Attribute values must support the same types as state variables: string, number, boolean, and null.
+9. Attributes must not interfere with state machine variables or rule evaluation.
+10. Attributes must be preserved through export operations.
+
+### 4.3 Filter Evaluation
+
+10. A filter engine must accept a built `StateMachine` and a filter definition, and return which states match the filter criteria.
+11. Filter rule conditions must be evaluated using the same `IExpressionEvaluator` used by the build system.
+12. States that match a filter rule must have the rule's specified attributes added to their `Attributes` dictionary.
+13. If a state matches multiple filter rules, attributes from all matching rules must be merged (later rules overwrite duplicate keys).
+
+### 4.4 Path Traversal Export
+
+14. Given a set of selected (filtered) states, the system must produce a new `StateMachine` containing only states on paths from the starting state to any selected state (forward reachability).
+15. The filtered state machine must include all transitions between the retained states.
+16. The starting state must always be included if any path exists to a selected state.
+17. States that are not on any path from the starting state to a selected state must be excluded.
+18. If no states match the filter, the resulting state machine must be empty (no states, no transitions).
+
+### 4.5 Console Integration
+
+19. A new `filter` command must be available: `statemaker.console filter <state-machine-file> <filter-definition-file> [options]`.
+20. The `filter` command must accept `--format` and `--output` options matching the existing `build` and `export` commands.
+21. The existing `export` command must accept an optional `--filter` option that takes a filter definition file path.
+22. When `--filter` is provided to `export`, the export must apply the filter and path traversal before exporting.
+23. Both commands must output the filtered state machine in the requested format (json, dot, graphml, mermaid).
+24. The `filter` command must accept a `--list` flag that outputs a JSON array of full state definitions for all states matching the filter criteria, without performing path traversal or full state machine export.
+
+### 4.6 Attribute Rendering in Exports
+
+25. Exporters should include state attributes in their output where the format supports it (e.g., as additional label lines, node styling, or metadata).
+26. Attributes must be visually distinguished from variables by default in label-based formats (e.g., separated by a divider or prefix).
+27. The JSON exporter must include attributes in the JSON output as a separate field from variables.
+
+## 5. Non-Goals (Out of Scope)
+
+- **Backward reachability**: Filtering paths that can reach a selected state from any state (not just from the starting state) is out of scope for this phase.
+- **Filter composition**: Combining multiple filter definition files or chaining filters is not included.
+- **Interactive filtering**: No interactive or GUI-based filtering interface.
+- **Modifying variables**: Filters select and annotate states but do not modify state machine variables.
+- **Import of filtered formats**: Importing a filtered state machine back with attribute preservation is not required.
+- **Custom attribute rendering**: Users may eventually want custom visual treatment for attributes (different colors, bold text, larger fonts, different node shapes, etc.). This is a future goal but out of scope for this phase. The current design should anticipate this extensibility.
+
+## 6. Design Considerations
+
+### Filter Definition File Example
+
+```json
+{
+  "filters": [
+    {
+      "condition": "Status == 'Approved' && Amount > 1000",
+      "attributes": {
+        "ranking": "high",
+        "category": "priority"
+      }
+    },
+    {
+      "condition": "IsComplete == true",
+      "attributes": {
+        "ranking": "low"
+      }
+    }
+  ]
+}
+```
+
+### State Attributes on State Class
+
+The `State` class gains a new `Attributes` dictionary alongside the existing `Variables` dictionary:
+
+```
+State
+├── Variables: { "Status": "Approved", "Amount": 1500 }
+└── Attributes: { "ranking": "high", "category": "priority" }
+```
+
+### Attribute Display in Exports
+
+In label-based formats (DOT, Mermaid, GraphML), attributes could appear as additional lines in the node label, visually separated from variables (e.g., with a divider or prefix).
+
+## 7. Technical Considerations
+
+- The expression evaluation must reuse the existing `IExpressionEvaluator` and `ExpressionEvaluator` implementation.
+- Path traversal filtering (forward reachability from starting state to selected nodes) is a graph algorithm — breadth-first or depth-first search from the starting state, retaining only paths that terminate at a selected state.
+- The `State` class change (adding `Attributes`) will affect serialization. JSON import/export must handle the new field with backward compatibility (missing `attributes` field defaults to empty dictionary).
+- Filter definition loading should follow the same patterns as `BuildDefinitionLoader` and `RuleFileLoader`, including `JsonParseException` for invalid JSON.
+
+## 8. Success Metrics
+
+- All existing tests continue to pass (no regressions from `State` class changes).
+- Filter rules correctly select states matching expression conditions.
+- Attributes are correctly attached to matching states and preserved in all export formats.
+- Path traversal produces correct reduced state machines (verified against known graph structures).
+- Console `filter` command and `export --filter` option produce expected output.
+- Round-trip: a state machine exported to JSON with attributes can be re-imported with attributes intact.
+
+## 9. Resolved Questions
+
+1. **Attribute value types**: Attribute key-value pairs support the same types as state variables (string, number, boolean, null).
+2. **Attribute rendering in exports**: Attributes are visually distinguished from variables by default (e.g., separated by a divider line or prefix). The design should anticipate future extensibility where users could specify custom visual treatment for attributes (different colors, bold, larger text, different node shapes, etc.), but custom rendering is out of scope for this PRD.
+3. **Listing matched states**: The `filter` command supports a `--list` flag that outputs a JSON array of full state definitions (not just IDs) for all states matching the filter criteria, without performing path traversal or full state machine export.

--- a/tasks/statefilteringdescription.txt
+++ b/tasks/statefilteringdescription.txt
@@ -1,0 +1,26 @@
+State filtering, selection and attribution.
+
+We want to be able to highlight states in a state machine definition which
+certain criteria and then use to for selection, filtering, marking up with special
+attributes and definition path traversal selection.
+
+- A rules based mechanism for selecting nodes inside a state machine. Uses
+similar rule expression mechanism as machine building, but rather than
+driving the creation of a state machine, selects or filters items from an
+already built state machine that match the criteria.
+
+- A markup mechanism that adds attributes to state machine nodes as indicated
+by the filtering rules. These attributes could be anything the filter
+indicates, for example "ranking":"low". The attributes would be a different
+set of properties on the state machine node than the state machine variables.
+
+- The ability to export state machines definitions that only include
+traversals that lead to one of the filtered nodes. This allows scenarios such
+as:
+
+Picking High Value Usage Paths
+A business analyst wants to know which sequence of actions lead to high
+priority features. They build a criteria for what the high priority features
+are, load a built state machine definition, and export it to a new state
+machine definition that now has all the ways through the machine that lead
+to the high priority features.

--- a/tasks/tasks-state-filtering.md
+++ b/tasks/tasks-state-filtering.md
@@ -1,0 +1,127 @@
+## Relevant Files
+
+- `src/StateMaker/State.cs` - Add `Attributes` dictionary property alongside existing `Variables`
+- `src/StateMaker.Tests/StateTests.cs` - Tests for `Attributes` on State (clone, equality, hashing)
+- `src/StateMaker/StateMachine.cs` - May need updates if StateMachine validates or copies state attributes
+- `src/StateMaker.Tests/StateMachineTests.cs` - Tests for StateMachine with attributed states
+- `src/StateMaker/FilterDefinition.cs` - New model class for filter definitions (conditions + attributes)
+- `src/StateMaker/FilterDefinitionLoader.cs` - New loader to parse filter definition JSON files
+- `src/StateMaker.Tests/FilterDefinitionLoaderTests.cs` - Tests for filter definition loading and validation
+- `src/StateMaker/FilterEngine.cs` - New engine that evaluates filter rules against state machine states
+- `src/StateMaker.Tests/FilterEngineTests.cs` - Tests for filter evaluation, attribute assignment, multi-rule merging
+- `src/StateMaker/PathFilter.cs` - New class for forward reachability path traversal
+- `src/StateMaker.Tests/PathFilterTests.cs` - Tests for path traversal with various graph topologies
+- `src/StateMaker/JsonExporter.cs` - Update to include attributes in JSON output
+- `src/StateMaker/JsonImporter.cs` - Update to read optional attributes from JSON
+- `src/StateMaker/DotExporter.cs` - Update to render attributes in node labels
+- `src/StateMaker/GraphMlExporter.cs` - Update to render attributes in node labels
+- `src/StateMaker/MermaidExporter.cs` - Update to render attributes in node labels
+- `src/StateMaker.Tests/ExporterTests.cs` - Tests for attribute rendering in all export formats
+- `src/StateMaker/FilterCommand.cs` - New console command for `filter`
+- `src/StateMaker/ExportCommand.cs` - Update to support `--filter` option
+- `src/StateMaker.Console/Program.cs` - Register `filter` command and update help text
+- `src/StateMaker/HelpPrinter.cs` - Update help text for new command and options
+- `src/StateMaker.Tests/FilterCommandTests.cs` - Tests for filter command
+- `src/StateMaker.Tests/ExportCommandTests.cs` - Tests for export with `--filter`
+- `src/StateMaker.Tests/ProgramTests.cs` - Tests for filter command routing
+- `src/StateMaker.Tests/HelpPrinterTests.cs` - Tests for updated help text
+- `docs/architecture/state-filtering.md` - Architecture documentation for filtering feature
+- `docs/statemaker-console-usage.md` - Update console usage docs with filter command
+
+### Notes
+
+- Unit tests are in `src/StateMaker.Tests/` alongside the project convention.
+- Use `dotnet test` to run all tests. Use `dotnet test --filter "FullyQualifiedName~ClassName"` to run specific test classes.
+- The existing `IExpressionEvaluator` and `ExpressionEvaluator` must be reused for filter condition evaluation.
+- The `State` class currently uses `Variables` as a `Dictionary<string, object>`. The new `Attributes` dictionary should follow the same pattern.
+- Filter definition JSON loading should follow the same patterns as `BuildDefinitionLoader` and `RuleFileLoader`, including `JsonParseException` for invalid JSON.
+
+## Instructions for Completing Tasks
+
+**IMPORTANT:** As you complete each task, you must check it off in this markdown file by changing `- [ ]` to `- [x]`. This helps track progress and ensures you don't skip any steps.
+
+Example:
+- `- [ ] 1.1 Read file` → `- [x] 1.1 Read file` (after completing)
+
+Update the file after completing each sub-task, not just after completing an entire parent task.
+
+**TDD Approach:** This project follows Test-Driven Development. When starting any new task or behavior change, follow the Red-Green-Refactor cycle:
+
+1. **Red (failing test):** Write the unit tests first, then create a **stub implementation** of the method under test (e.g., returning a default value, throwing `NotImplementedException`, or providing an obviously incomplete body). Run the tests and confirm they **fail due to insufficient functionality** — not merely due to a missing method or compilation error. This step validates that the tests are actually verifying meaningful behavior.
+2. **Green (make it pass):** Write the minimum correct implementation to make all tests pass.
+3. **Refactor:** Clean up the implementation while keeping all tests green.
+
+All tests must pass before moving on to the next sub-task.
+
+## Tasks
+
+- [ ] 0.0 Create feature branch
+  - [ ] 0.1 Create and checkout a new branch for this feature (e.g., `git checkout -b feature/state-filtering`)
+
+- [ ] 1.0 Add `Attributes` dictionary to the `State` class and update serialization
+  - [ ] 1.1 Add an `Attributes` property (`Dictionary<string, object>`) to the `State` class, initialized to an empty dictionary
+  - [ ] 1.2 Update `State.Clone()` to deep-copy the `Attributes` dictionary
+  - [ ] 1.3 Update `State.Equals()` and `State.GetHashCode()` to include `Attributes`
+  - [ ] 1.4 Update `JsonExporter` to include `attributes` as a separate field in JSON output (omit or output empty object when no attributes)
+  - [ ] 1.5 Update `JsonImporter` to read the optional `attributes` field from JSON (default to empty dictionary if missing, for backward compatibility)
+  - [ ] 1.6 Add tests in `StateTests.cs` for clone, equality, and hashing with attributes
+  - [ ] 1.7 Add tests in `ExporterTests.cs` for JSON round-trip with attributes
+  - [ ] 1.8 Run all tests and confirm no regressions from the `State` class changes
+
+- [ ] 2.0 Create filter definition model and loader
+  - [ ] 2.1 Create `FilterRule` model class with `Condition` (string) and `Attributes` (dictionary) properties
+  - [ ] 2.2 Create `FilterDefinition` model class containing a list of `FilterRule` objects
+  - [ ] 2.3 Create `FilterDefinitionLoader` class with `LoadFromFile(string path)` and `LoadFromJson(string json)` methods, following the same patterns as `BuildDefinitionLoader` and `RuleFileLoader`
+  - [ ] 2.4 Handle invalid JSON with `JsonParseException`, validate required fields (e.g., `condition` must be present)
+  - [ ] 2.5 Support requirement 4.1.6: allow `condition` to refer to the state ID (add a reserved variable name like `_stateId` that gets injected during evaluation)
+  - [ ] 2.6 Add tests in `FilterDefinitionLoaderTests.cs` for valid definitions, missing fields, invalid JSON, multiple rules, and empty filters
+  - [ ] 2.7 Run tests and confirm all pass
+
+- [ ] 3.0 Create filter engine (evaluate filter rules against state machine states)
+  - [ ] 3.1 Create `FilterEngine` class that accepts a `StateMachine`, a `FilterDefinition`, and an `IExpressionEvaluator`
+  - [ ] 3.2 Implement evaluation: iterate all states, evaluate each filter rule condition against the state's variables, collect matching states
+  - [ ] 3.3 Inject the state ID as a reserved variable (e.g., `_stateId`) so conditions can reference it per requirement 4.1.6
+  - [ ] 3.4 Implement attribute assignment: add each matching rule's attributes to the state's `Attributes` dictionary, with later rules overwriting duplicate keys
+  - [ ] 3.5 Return the set of selected state IDs (and the state machine with attributes applied)
+  - [ ] 3.6 Add tests in `FilterEngineTests.cs`: single rule match, no matches, multiple rules with attribute merging, condition referencing state ID, expression evaluation errors
+  - [ ] 3.7 Run tests and confirm all pass
+
+- [ ] 4.0 Create path traversal filter (forward reachability from starting state to selected states)
+  - [ ] 4.1 Create `PathFilter` class that accepts a `StateMachine` and a set of selected state IDs
+  - [ ] 4.2 Implement forward reachability: find all paths from starting state to any selected state using BFS/DFS
+  - [ ] 4.3 Produce a new `StateMachine` containing only the states on those paths and their connecting transitions
+  - [ ] 4.4 Always include the starting state if any path exists to a selected state
+  - [ ] 4.5 Return an empty state machine (no states, no transitions) if no states match the filter
+  - [ ] 4.6 Add tests in `PathFilterTests.cs`: linear chain, branching paths, cycles, no matches yields empty machine, starting state inclusion, states not on path excluded
+  - [ ] 4.7 Run tests and confirm all pass
+
+- [ ] 5.0 Update exporters to render attributes (visually distinguished from variables)
+  - [ ] 5.1 Update `DotExporter` to include attributes in node labels, visually separated from variables (e.g., with a divider line or prefix)
+  - [ ] 5.2 Update `MermaidExporter` to include attributes in node labels, visually separated from variables
+  - [ ] 5.3 Update `GraphMlExporter` to include attributes in node labels, visually separated from variables
+  - [ ] 5.4 Ensure exporters handle states with no attributes gracefully (no divider or extra whitespace)
+  - [ ] 5.5 Add tests in `ExporterTests.cs` for each exporter with states that have attributes and states without attributes
+  - [ ] 5.6 Run tests and confirm all pass
+
+- [ ] 6.0 Add `filter` console command and `--filter` option on `export` command
+  - [ ] 6.1 Create `FilterCommand` class following the pattern of `BuildCommand` and `ExportCommand`: load state machine, load filter definition, run filter engine, run path traversal, export result
+  - [ ] 6.2 Update `ExportCommand` to accept an optional `--filter` argument; when provided, apply filter engine and path traversal before exporting
+  - [ ] 6.3 Update `Program.cs` to route the `filter` command to `FilterCommand`
+  - [ ] 6.4 Update `HelpPrinter` with usage text for the `filter` command and `--filter` option on `export`
+  - [ ] 6.5 Add tests in `FilterCommandTests.cs` for successful filtering, missing files, invalid filter definition, and output format options
+  - [ ] 6.6 Add tests in `ExportCommandTests.cs` for the `--filter` option
+  - [ ] 6.7 Update `ProgramTests.cs` for filter command routing
+  - [ ] 6.8 Update `HelpPrinterTests.cs` for new help text
+  - [ ] 6.9 Run tests and confirm all pass
+
+- [ ] 7.0 Add `--list` flag support to the `filter` command
+  - [ ] 7.1 Update `FilterCommand` to accept a `--list` flag
+  - [ ] 7.2 When `--list` is provided, output a JSON array of full state definitions (with variables and attributes) for matching states, without path traversal
+  - [ ] 7.3 Add tests in `FilterCommandTests.cs` for `--list` flag output format and content
+  - [ ] 7.4 Update `HelpPrinter` with `--list` option documentation
+  - [ ] 7.5 Run tests and confirm all pass
+
+- [ ] 8.0 Update documentation
+  - [ ] 8.1 Create `docs/architecture/state-filtering.md` covering filter definition format, filter engine, path traversal algorithm, and attribute rendering
+  - [ ] 8.2 Update `docs/statemaker-console-usage.md` with `filter` command usage, `--filter` option on `export`, `--list` flag, and example output
+  - [ ] 8.3 Run full test suite and Release build as final verification


### PR DESCRIPTION
## Summary
- Add product description, PRD, and task breakdown for state filtering, selection, and attribution feature
- Filter engine selects states from built state machines using NCalc expression conditions
- Markup attributes stored separately from state variables on State class
- Forward reachability path traversal exports reduced state machines
- Console integration: standalone filter command and --filter option on export
- --list flag outputs JSON array of matching state definitions

## Files
- tasks/statefilteringdescription.txt - Original feature description
- tasks/prd-state-filtering.md - Full PRD with requirements, design, and resolved questions
- tasks/tasks-state-filtering.md - Implementation task breakdown with TDD approach

## Test plan
- [ ] No code changes in this PR - planning documents only
- [ ] Review PRD requirements and task breakdown for completeness

Generated with [Claude Code](https://claude.com/claude-code)