### PR TITLE
Add filter engine with condition evaluation (task 3.0)

### DIFF
--- a/src/StateMaker.Tests/FilterEngineTests.cs
+++ b/src/StateMaker.Tests/FilterEngineTests.cs
@@ -1,0 +1,291 @@
+namespace StateMaker.Tests;
+
+public class FilterEngineTests
+{
+    private readonly IExpressionEvaluator _evaluator = new ExpressionEvaluator();
+
+    #region Helper Methods
+
+    private static StateMachine CreateMachineWithStates(params (string id, (string key, object? value)[] vars)[] states)
+    {
+        var machine = new StateMachine();
+        foreach (var (id, vars) in states)
+        {
+            var state = new State();
+            foreach (var (key, value) in vars)
+            {
+                state.Variables[key] = value;
+            }
+            machine.AddOrUpdateState(id, state);
+        }
+        if (states.Length > 0)
+            machine.StartingStateId = states[0].id;
+        return machine;
+    }
+
+    private static FilterDefinition CreateFilterDefinition(params (string condition, (string key, object? value)[] attrs)[] filters)
+    {
+        var definition = new FilterDefinition();
+        foreach (var (condition, attrs) in filters)
+        {
+            var rule = new FilterRule { Condition = condition };
+            foreach (var (key, value) in attrs)
+            {
+                rule.Attributes[key] = value;
+            }
+            definition.Filters.Add(rule);
+        }
+        return definition;
+    }
+
+    #endregion
+
+    #region Single Rule Matching
+
+    [Fact]
+    public void Apply_SingleRuleMatchesOneState_ReturnsMatchingStateId()
+    {
+        var machine = CreateMachineWithStates(
+            ("S0", new[] { ("Status", (object?)"Pending") }),
+            ("S1", new[] { ("Status", (object?)"Approved") })
+        );
+        var filter = CreateFilterDefinition(
+            ("[Status] == 'Approved'", new[] { ("ranking", (object?)"high") })
+        );
+
+        var result = new FilterEngine(_evaluator).Apply(machine, filter);
+
+        Assert.Single(result.SelectedStateIds);
+        Assert.Contains("S1", result.SelectedStateIds);
+    }
+
+    [Fact]
+    public void Apply_SingleRuleMatchesMultipleStates_ReturnsAll()
+    {
+        var machine = CreateMachineWithStates(
+            ("S0", new[] { ("Status", (object?)"Approved") }),
+            ("S1", new[] { ("Status", (object?)"Approved") }),
+            ("S2", new[] { ("Status", (object?)"Pending") })
+        );
+        var filter = CreateFilterDefinition(
+            ("[Status] == 'Approved'", new[] { ("ranking", (object?)"high") })
+        );
+
+        var result = new FilterEngine(_evaluator).Apply(machine, filter);
+
+        Assert.Equal(2, result.SelectedStateIds.Count);
+        Assert.Contains("S0", result.SelectedStateIds);
+        Assert.Contains("S1", result.SelectedStateIds);
+    }
+
+    #endregion
+
+    #region No Matches
+
+    [Fact]
+    public void Apply_NoStatesMatch_ReturnsEmpty()
+    {
+        var machine = CreateMachineWithStates(
+            ("S0", new[] { ("Status", (object?)"Pending") }),
+            ("S1", new[] { ("Status", (object?)"Pending") })
+        );
+        var filter = CreateFilterDefinition(
+            ("[Status] == 'Approved'", new[] { ("ranking", (object?)"high") })
+        );
+
+        var result = new FilterEngine(_evaluator).Apply(machine, filter);
+
+        Assert.Empty(result.SelectedStateIds);
+    }
+
+    #endregion
+
+    #region Attribute Assignment
+
+    [Fact]
+    public void Apply_MatchingRule_AppliesAttributesToState()
+    {
+        var machine = CreateMachineWithStates(
+            ("S0", new[] { ("Status", (object?)"Approved") })
+        );
+        var filter = CreateFilterDefinition(
+            ("[Status] == 'Approved'", new[] { ("ranking", (object?)"high"), ("priority", (object?)1) })
+        );
+
+        var result = new FilterEngine(_evaluator).Apply(machine, filter);
+
+        var state = result.StateMachine.States["S0"];
+        Assert.Equal("high", state.Attributes["ranking"]);
+        Assert.Equal(1, state.Attributes["priority"]);
+    }
+
+    [Fact]
+    public void Apply_NonMatchingRule_DoesNotApplyAttributes()
+    {
+        var machine = CreateMachineWithStates(
+            ("S0", new[] { ("Status", (object?)"Pending") })
+        );
+        var filter = CreateFilterDefinition(
+            ("[Status] == 'Approved'", new[] { ("ranking", (object?)"high") })
+        );
+
+        var result = new FilterEngine(_evaluator).Apply(machine, filter);
+
+        var state = result.StateMachine.States["S0"];
+        Assert.Empty(state.Attributes);
+    }
+
+    #endregion
+
+    #region Multiple Rules with Attribute Merging
+
+    [Fact]
+    public void Apply_MultipleRulesMatch_MergesAttributes()
+    {
+        var machine = CreateMachineWithStates(
+            ("S0", new[] { ("Status", (object?)"Approved"), ("Count", (object?)10) })
+        );
+        var filter = CreateFilterDefinition(
+            ("[Status] == 'Approved'", new[] { ("ranking", (object?)"high") }),
+            ("[Count] > 5", new[] { ("category", (object?)"large") })
+        );
+
+        var result = new FilterEngine(_evaluator).Apply(machine, filter);
+
+        var state = result.StateMachine.States["S0"];
+        Assert.Equal("high", state.Attributes["ranking"]);
+        Assert.Equal("large", state.Attributes["category"]);
+    }
+
+    [Fact]
+    public void Apply_MultipleRulesMatch_LaterRuleOverwritesDuplicateKeys()
+    {
+        var machine = CreateMachineWithStates(
+            ("S0", new[] { ("Status", (object?)"Approved"), ("Count", (object?)10) })
+        );
+        var filter = CreateFilterDefinition(
+            ("[Status] == 'Approved'", new[] { ("ranking", (object?)"high") }),
+            ("[Count] > 5", new[] { ("ranking", (object?)"medium") })
+        );
+
+        var result = new FilterEngine(_evaluator).Apply(machine, filter);
+
+        var state = result.StateMachine.States["S0"];
+        Assert.Equal("medium", state.Attributes["ranking"]);
+    }
+
+    [Fact]
+    public void Apply_OnlyFirstRuleMatches_OnlyFirstAttributesApplied()
+    {
+        var machine = CreateMachineWithStates(
+            ("S0", new[] { ("Status", (object?)"Approved"), ("Count", (object?)2) })
+        );
+        var filter = CreateFilterDefinition(
+            ("[Status] == 'Approved'", new[] { ("ranking", (object?)"high") }),
+            ("[Count] > 5", new[] { ("category", (object?)"large") })
+        );
+
+        var result = new FilterEngine(_evaluator).Apply(machine, filter);
+
+        var state = result.StateMachine.States["S0"];
+        Assert.Equal("high", state.Attributes["ranking"]);
+        Assert.False(state.Attributes.ContainsKey("category"));
+    }
+
+    #endregion
+
+    #region State ID in Conditions
+
+    [Fact]
+    public void Apply_ConditionReferencesStateId_MatchesCorrectState()
+    {
+        var machine = CreateMachineWithStates(
+            ("S0", new[] { ("Status", (object?)"Pending") }),
+            ("S1", new[] { ("Status", (object?)"Pending") }),
+            ("TargetState", new[] { ("Status", (object?)"Pending") })
+        );
+        var filter = CreateFilterDefinition(
+            ($"[{FilterEngine.StateIdVariableName}] == 'TargetState'", new[] { ("selected", (object?)true) })
+        );
+
+        var result = new FilterEngine(_evaluator).Apply(machine, filter);
+
+        Assert.Single(result.SelectedStateIds);
+        Assert.Contains("TargetState", result.SelectedStateIds);
+        Assert.Equal(true, result.StateMachine.States["TargetState"].Attributes["selected"]);
+    }
+
+    [Fact]
+    public void Apply_ConditionCombinesStateIdAndVariable_MatchesCorrectly()
+    {
+        var machine = CreateMachineWithStates(
+            ("S0", new[] { ("Status", (object?)"Approved") }),
+            ("S1", new[] { ("Status", (object?)"Approved") }),
+            ("S2", new[] { ("Status", (object?)"Pending") })
+        );
+        var filter = CreateFilterDefinition(
+            ($"[{FilterEngine.StateIdVariableName}] == 'S1' && [Status] == 'Approved'", new[] { ("match", (object?)"exact") })
+        );
+
+        var result = new FilterEngine(_evaluator).Apply(machine, filter);
+
+        Assert.Single(result.SelectedStateIds);
+        Assert.Contains("S1", result.SelectedStateIds);
+    }
+
+    #endregion
+
+    #region Expression Evaluation Errors
+
+    [Fact]
+    public void Apply_InvalidExpression_ThrowsExpressionEvaluationException()
+    {
+        var machine = CreateMachineWithStates(
+            ("S0", new[] { ("Status", (object?)"Pending") })
+        );
+        var filter = CreateFilterDefinition(
+            ("this is not valid !!!", new[] { ("ranking", (object?)"high") })
+        );
+
+        Assert.Throws<ExpressionEvaluationException>(() =>
+            new FilterEngine(_evaluator).Apply(machine, filter));
+    }
+
+    #endregion
+
+    #region Result StateMachine Preserves Structure
+
+    [Fact]
+    public void Apply_PreservesAllStatesInResultMachine()
+    {
+        var machine = CreateMachineWithStates(
+            ("S0", new[] { ("Status", (object?)"Pending") }),
+            ("S1", new[] { ("Status", (object?)"Approved") })
+        );
+        machine.Transitions.Add(new Transition("S0", "S1", "Approve"));
+
+        var filter = CreateFilterDefinition(
+            ("[Status] == 'Approved'", new[] { ("ranking", (object?)"high") })
+        );
+
+        var result = new FilterEngine(_evaluator).Apply(machine, filter);
+
+        Assert.Equal(2, result.StateMachine.States.Count);
+        Assert.Single(result.StateMachine.Transitions);
+    }
+
+    [Fact]
+    public void Apply_EmptyFilterDefinition_ReturnsNoMatches()
+    {
+        var machine = CreateMachineWithStates(
+            ("S0", new[] { ("Status", (object?)"Pending") })
+        );
+        var filter = new FilterDefinition();
+
+        var result = new FilterEngine(_evaluator).Apply(machine, filter);
+
+        Assert.Empty(result.SelectedStateIds);
+    }
+
+    #endregion
+}

--- a/src/StateMaker/FilterEngine.cs
+++ b/src/StateMaker/FilterEngine.cs
@@ -1,0 +1,58 @@
+namespace StateMaker;
+
+public class FilterResult
+{
+    public HashSet<string> SelectedStateIds { get; } = new();
+    public StateMachine StateMachine { get; set; } = new();
+}
+
+public class FilterEngine
+{
+    public const string StateIdVariableName = "_stateId";
+
+    private readonly IExpressionEvaluator _evaluator;
+
+    public FilterEngine(IExpressionEvaluator evaluator)
+    {
+        _evaluator = evaluator;
+    }
+
+    public FilterResult Apply(StateMachine stateMachine, FilterDefinition filterDefinition)
+    {
+        var result = new FilterResult { StateMachine = stateMachine };
+
+        foreach (var kvp in stateMachine.States)
+        {
+            var stateId = kvp.Key;
+            var state = kvp.Value;
+            var variables = GetNonNullableVariables(state);
+            variables[StateIdVariableName] = stateId;
+
+            foreach (var rule in filterDefinition.Filters)
+            {
+                if (_evaluator.EvaluateBoolean(rule.Condition, variables))
+                {
+                    result.SelectedStateIds.Add(stateId);
+
+                    foreach (var attr in rule.Attributes)
+                    {
+                        state.Attributes[attr.Key] = attr.Value;
+                    }
+                }
+            }
+        }
+
+        return result;
+    }
+
+    private static Dictionary<string, object> GetNonNullableVariables(State state)
+    {
+        var dict = new Dictionary<string, object>();
+        foreach (var kvp in state.Variables)
+        {
+            if (kvp.Value is not null)
+                dict[kvp.Key] = kvp.Value;
+        }
+        return dict;
+    }
+}

--- a/tasks/tasks-state-filtering.md
+++ b/tasks/tasks-state-filtering.md
@@ -77,14 +77,14 @@ All tests must pass before moving on to the next sub-task.
   - [x] 2.6 Add tests in `FilterDefinitionLoaderTests.cs` for valid definitions, missing fields, invalid JSON, multiple rules, and empty filters
   - [x] 2.7 Run tests and confirm all pass
 
-- [ ] 3.0 Create filter engine (evaluate filter rules against state machine states)
-  - [ ] 3.1 Create `FilterEngine` class that accepts a `StateMachine`, a `FilterDefinition`, and an `IExpressionEvaluator`
-  - [ ] 3.2 Implement evaluation: iterate all states, evaluate each filter rule condition against the state's variables, collect matching states
-  - [ ] 3.3 Inject the state ID as a reserved variable (e.g., `_stateId`) so conditions can reference it per requirement 4.1.6
-  - [ ] 3.4 Implement attribute assignment: add each matching rule's attributes to the state's `Attributes` dictionary, with later rules overwriting duplicate keys
-  - [ ] 3.5 Return the set of selected state IDs (and the state machine with attributes applied)
-  - [ ] 3.6 Add tests in `FilterEngineTests.cs`: single rule match, no matches, multiple rules with attribute merging, condition referencing state ID, expression evaluation errors
-  - [ ] 3.7 Run tests and confirm all pass
+- [x] 3.0 Create filter engine (evaluate filter rules against state machine states)
+  - [x] 3.1 Create `FilterEngine` class that accepts a `StateMachine`, a `FilterDefinition`, and an `IExpressionEvaluator`
+  - [x] 3.2 Implement evaluation: iterate all states, evaluate each filter rule condition against the state's variables, collect matching states
+  - [x] 3.3 Inject the state ID as a reserved variable (e.g., `_stateId`) so conditions can reference it per requirement 4.1.6
+  - [x] 3.4 Implement attribute assignment: add each matching rule's attributes to the state's `Attributes` dictionary, with later rules overwriting duplicate keys
+  - [x] 3.5 Return the set of selected state IDs (and the state machine with attributes applied)
+  - [x] 3.6 Add tests in `FilterEngineTests.cs`: single rule match, no matches, multiple rules with attribute merging, condition referencing state ID, expression evaluation errors
+  - [x] 3.7 Run tests and confirm all pass
 
 - [ ] 4.0 Create path traversal filter (forward reachability from starting state to selected states)
   - [ ] 4.1 Create `PathFilter` class that accepts a `StateMachine` and a set of selected state IDs


### PR DESCRIPTION
## Summary
- Created FilterEngine class that evaluates filter rule conditions against state machine states using IExpressionEvaluator
- Injects _stateId as a reserved variable (via public const StateIdVariableName) so conditions can reference state IDs
- Applies matching rule attributes to states, with later rules overwriting duplicate keys
- Returns FilterResult containing selected state IDs and the state machine with attributes applied
- Added 13 TDD tests covering single/multiple rule matching, no matches, attribute assignment and merging, state ID conditions, invalid expressions, and structure preservation

## Test plan
- [x] All 13 FilterEngineTests pass
- [x] Full test suite (776 tests) passes with no regressions
- [x] Task 3.0 subtasks checked off in task list

Generated with Claude Code