### PR TITLE
Add path filter with forward+reverse BFS (task 4.0)

### DIFF
--- a/docs/test/test-battery-observations.md
+++ b/docs/test/test-battery-observations.md
@@ -1,0 +1,37 @@
+# Test Battery Observations
+
+## Intermittent Failure: RunSingle_ReverseGenerated_PassesAllOracles
+
+**Observed:** During a full test suite run on the `feature/path-filter` branch, one instance
+of `RunSingle_ReverseGenerated_PassesAllOracles` failed. The failure could not be reproduced
+in five consecutive full suite runs or when the test was run in isolation.
+
+**Suspected Cause:** Oracle 6 in `TestBatteryExecutor` checks a performance heuristic —
+if `elapsed_ms / state_count > 100ms/state`, the test fails. During parallel test execution,
+system load can inflate elapsed time enough to trip this threshold, especially for definitions
+that produce very few states (where a small absolute delay causes a large ms/state ratio).
+
+**Status:** Under observation. Failure reasons are now logged via `ITestOutputHelper` so that
+if the failure recurs, the exact definition name, failure reason, state count, transition count,
+and elapsed time will be captured in test output.
+
+## Potential Mitigations (NOT YET COMMITTED — proposals only)
+
+The following mitigations are being considered. None have been applied because we do not yet
+have enough data to confirm the root cause. Apply only after observing and understanding
+the failure reason from a recurrence.
+
+1. **Increase the ms/state threshold for battery tests.**
+   Pass a higher `msPerStateThreshold` (e.g., 500ms) to `TestBatteryExecutor.Run()` in
+   the Theory-based tests. This reduces sensitivity to system load but weakens the
+   performance oracle's ability to detect real regressions.
+
+2. **Separate performance-sensitive tests with `[Trait]`.**
+   Tag tests that exercise Oracle 6 with `[Trait("Category", "Performance")]` so they can
+   be run in isolation (e.g., `dotnet test --filter Category=Performance`) where system load
+   is controlled. Other oracle checks would still run in the full suite.
+
+3. **Exclude Oracle 6 from per-definition `RunSingle` tests.**
+   Use the `msPerStateThreshold` parameter to effectively disable Oracle 6 in the Theory
+   tests (set threshold to `double.MaxValue`), while keeping it active in the `RunAll`
+   sweep tests where aggregation smooths out individual timing noise.

--- a/src/StateMaker.Tests/PathFilterTests.cs
+++ b/src/StateMaker.Tests/PathFilterTests.cs
@@ -1,0 +1,451 @@
+namespace StateMaker.Tests;
+
+public class PathFilterTests
+{
+    #region Linear Chain
+
+    [Fact]
+    public void Filter_LinearChain_SelectedAtEnd_IncludesFullPath()
+    {
+        // S0 -> S1 -> S2 (selected)
+        var machine = new StateMachine();
+        machine.AddOrUpdateState("S0", new State());
+        machine.AddOrUpdateState("S1", new State());
+        machine.AddOrUpdateState("S2", new State());
+        machine.StartingStateId = "S0";
+        machine.Transitions.Add(new Transition("S0", "S1", "R1"));
+        machine.Transitions.Add(new Transition("S1", "S2", "R2"));
+
+        var selected = new HashSet<string> { "S2" };
+
+        var result = new PathFilter(machine, selected).Filter();
+
+        Assert.Equal(3, result.States.Count);
+        Assert.Contains("S0", result.States.Keys);
+        Assert.Contains("S1", result.States.Keys);
+        Assert.Contains("S2", result.States.Keys);
+        Assert.Equal(2, result.Transitions.Count);
+        Assert.Equal("S0", result.StartingStateId);
+    }
+
+    [Fact]
+    public void Filter_LinearChain_SelectedInMiddle_ExcludesAfterSelected()
+    {
+        // S0 -> S1 (selected) -> S2
+        var machine = new StateMachine();
+        machine.AddOrUpdateState("S0", new State());
+        machine.AddOrUpdateState("S1", new State());
+        machine.AddOrUpdateState("S2", new State());
+        machine.StartingStateId = "S0";
+        machine.Transitions.Add(new Transition("S0", "S1", "R1"));
+        machine.Transitions.Add(new Transition("S1", "S2", "R2"));
+
+        var selected = new HashSet<string> { "S1" };
+
+        var result = new PathFilter(machine, selected).Filter();
+
+        Assert.Equal(2, result.States.Count);
+        Assert.Contains("S0", result.States.Keys);
+        Assert.Contains("S1", result.States.Keys);
+        Assert.DoesNotContain("S2", result.States.Keys);
+        Assert.Single(result.Transitions);
+    }
+
+    #endregion
+
+    #region Branching Paths
+
+    [Fact]
+    public void Filter_BranchingPaths_OnlyIncludesPathToSelected()
+    {
+        // S0 -> S1 -> S2 (selected)
+        // S0 -> S3 -> S4
+        var machine = new StateMachine();
+        machine.AddOrUpdateState("S0", new State());
+        machine.AddOrUpdateState("S1", new State());
+        machine.AddOrUpdateState("S2", new State());
+        machine.AddOrUpdateState("S3", new State());
+        machine.AddOrUpdateState("S4", new State());
+        machine.StartingStateId = "S0";
+        machine.Transitions.Add(new Transition("S0", "S1", "R1"));
+        machine.Transitions.Add(new Transition("S1", "S2", "R2"));
+        machine.Transitions.Add(new Transition("S0", "S3", "R3"));
+        machine.Transitions.Add(new Transition("S3", "S4", "R4"));
+
+        var selected = new HashSet<string> { "S2" };
+
+        var result = new PathFilter(machine, selected).Filter();
+
+        Assert.Equal(3, result.States.Count);
+        Assert.Contains("S0", result.States.Keys);
+        Assert.Contains("S1", result.States.Keys);
+        Assert.Contains("S2", result.States.Keys);
+        Assert.DoesNotContain("S3", result.States.Keys);
+        Assert.DoesNotContain("S4", result.States.Keys);
+        Assert.Equal(2, result.Transitions.Count);
+    }
+
+    [Fact]
+    public void Filter_BranchingPaths_MultipleSelectedOnDifferentBranches()
+    {
+        // S0 -> S1 -> S2 (selected)
+        // S0 -> S3 -> S4 (selected)
+        var machine = new StateMachine();
+        machine.AddOrUpdateState("S0", new State());
+        machine.AddOrUpdateState("S1", new State());
+        machine.AddOrUpdateState("S2", new State());
+        machine.AddOrUpdateState("S3", new State());
+        machine.AddOrUpdateState("S4", new State());
+        machine.StartingStateId = "S0";
+        machine.Transitions.Add(new Transition("S0", "S1", "R1"));
+        machine.Transitions.Add(new Transition("S1", "S2", "R2"));
+        machine.Transitions.Add(new Transition("S0", "S3", "R3"));
+        machine.Transitions.Add(new Transition("S3", "S4", "R4"));
+
+        var selected = new HashSet<string> { "S2", "S4" };
+
+        var result = new PathFilter(machine, selected).Filter();
+
+        Assert.Equal(5, result.States.Count);
+        Assert.Equal(4, result.Transitions.Count);
+    }
+
+    #endregion
+
+    #region Convergent Paths
+
+    [Fact]
+    public void Filter_TwoBranchesConvergeOnSelectedState_BothBranchesIncluded()
+    {
+        // S0 -> S1 -> S3 (selected)
+        // S0 -> S2 -> S3 (selected)
+        var machine = new StateMachine();
+        machine.AddOrUpdateState("S0", new State());
+        machine.AddOrUpdateState("S1", new State());
+        machine.AddOrUpdateState("S2", new State());
+        machine.AddOrUpdateState("S3", new State());
+        machine.StartingStateId = "S0";
+        machine.Transitions.Add(new Transition("S0", "S1", "R1"));
+        machine.Transitions.Add(new Transition("S1", "S3", "R2"));
+        machine.Transitions.Add(new Transition("S0", "S2", "R3"));
+        machine.Transitions.Add(new Transition("S2", "S3", "R4"));
+
+        var selected = new HashSet<string> { "S3" };
+
+        var result = new PathFilter(machine, selected).Filter();
+
+        Assert.Equal(4, result.States.Count);
+        Assert.Contains("S0", result.States.Keys);
+        Assert.Contains("S1", result.States.Keys);
+        Assert.Contains("S2", result.States.Keys);
+        Assert.Contains("S3", result.States.Keys);
+        Assert.Equal(4, result.Transitions.Count);
+    }
+
+    [Fact]
+    public void Filter_TwoBranchesConvergeThenSelectedOneStepLater_BothBranchesIncluded()
+    {
+        // S0 -> S1 -> S3 -> S4 (selected)
+        // S0 -> S2 -> S3 -> S4 (selected)
+        var machine = new StateMachine();
+        machine.AddOrUpdateState("S0", new State());
+        machine.AddOrUpdateState("S1", new State());
+        machine.AddOrUpdateState("S2", new State());
+        machine.AddOrUpdateState("S3", new State());
+        machine.AddOrUpdateState("S4", new State());
+        machine.StartingStateId = "S0";
+        machine.Transitions.Add(new Transition("S0", "S1", "R1"));
+        machine.Transitions.Add(new Transition("S1", "S3", "R2"));
+        machine.Transitions.Add(new Transition("S0", "S2", "R3"));
+        machine.Transitions.Add(new Transition("S2", "S3", "R4"));
+        machine.Transitions.Add(new Transition("S3", "S4", "R5"));
+
+        var selected = new HashSet<string> { "S4" };
+
+        var result = new PathFilter(machine, selected).Filter();
+
+        Assert.Equal(5, result.States.Count);
+        Assert.Contains("S0", result.States.Keys);
+        Assert.Contains("S1", result.States.Keys);
+        Assert.Contains("S2", result.States.Keys);
+        Assert.Contains("S3", result.States.Keys);
+        Assert.Contains("S4", result.States.Keys);
+        Assert.Equal(5, result.Transitions.Count);
+    }
+
+    [Fact]
+    public void Filter_ConvergentWithDeadBranch_DeadBranchExcluded()
+    {
+        // S0 -> S1 -> S3 -> S4 (selected)
+        // S0 -> S2 -> S3 -> S4 (selected)
+        // S0 -> S5 -> S6 (not selected, dead branch)
+        var machine = new StateMachine();
+        machine.AddOrUpdateState("S0", new State());
+        machine.AddOrUpdateState("S1", new State());
+        machine.AddOrUpdateState("S2", new State());
+        machine.AddOrUpdateState("S3", new State());
+        machine.AddOrUpdateState("S4", new State());
+        machine.AddOrUpdateState("S5", new State());
+        machine.AddOrUpdateState("S6", new State());
+        machine.StartingStateId = "S0";
+        machine.Transitions.Add(new Transition("S0", "S1", "R1"));
+        machine.Transitions.Add(new Transition("S1", "S3", "R2"));
+        machine.Transitions.Add(new Transition("S0", "S2", "R3"));
+        machine.Transitions.Add(new Transition("S2", "S3", "R4"));
+        machine.Transitions.Add(new Transition("S3", "S4", "R5"));
+        machine.Transitions.Add(new Transition("S0", "S5", "R6"));
+        machine.Transitions.Add(new Transition("S5", "S6", "R7"));
+
+        var selected = new HashSet<string> { "S4" };
+
+        var result = new PathFilter(machine, selected).Filter();
+
+        Assert.Equal(5, result.States.Count);
+        Assert.Contains("S0", result.States.Keys);
+        Assert.Contains("S1", result.States.Keys);
+        Assert.Contains("S2", result.States.Keys);
+        Assert.Contains("S3", result.States.Keys);
+        Assert.Contains("S4", result.States.Keys);
+        Assert.DoesNotContain("S5", result.States.Keys);
+        Assert.DoesNotContain("S6", result.States.Keys);
+        Assert.Equal(5, result.Transitions.Count);
+    }
+
+    [Fact]
+    public void Filter_ConvergentOnSelected_OneBranchHasNonSelectedSpur_SpurExcluded()
+    {
+        // S0 -> S1 -> S3 (selected)
+        // S0 -> S2 -> S3 (selected)
+        // S1 -> S5 (spur off convergent branch, not selected)
+        var machine = new StateMachine();
+        machine.AddOrUpdateState("S0", new State());
+        machine.AddOrUpdateState("S1", new State());
+        machine.AddOrUpdateState("S2", new State());
+        machine.AddOrUpdateState("S3", new State());
+        machine.AddOrUpdateState("S5", new State());
+        machine.StartingStateId = "S0";
+        machine.Transitions.Add(new Transition("S0", "S1", "R1"));
+        machine.Transitions.Add(new Transition("S1", "S3", "R2"));
+        machine.Transitions.Add(new Transition("S0", "S2", "R3"));
+        machine.Transitions.Add(new Transition("S2", "S3", "R4"));
+        machine.Transitions.Add(new Transition("S1", "S5", "R5"));
+
+        var selected = new HashSet<string> { "S3" };
+
+        var result = new PathFilter(machine, selected).Filter();
+
+        Assert.Equal(4, result.States.Count);
+        Assert.Contains("S0", result.States.Keys);
+        Assert.Contains("S1", result.States.Keys);
+        Assert.Contains("S2", result.States.Keys);
+        Assert.Contains("S3", result.States.Keys);
+        Assert.DoesNotContain("S5", result.States.Keys);
+    }
+
+    [Fact]
+    public void Filter_ThreeBranchesConvergeOnSelected_AllThreeIncluded()
+    {
+        // S0 -> S1 -> S4 (selected)
+        // S0 -> S2 -> S4 (selected)
+        // S0 -> S3 -> S4 (selected)
+        var machine = new StateMachine();
+        machine.AddOrUpdateState("S0", new State());
+        machine.AddOrUpdateState("S1", new State());
+        machine.AddOrUpdateState("S2", new State());
+        machine.AddOrUpdateState("S3", new State());
+        machine.AddOrUpdateState("S4", new State());
+        machine.StartingStateId = "S0";
+        machine.Transitions.Add(new Transition("S0", "S1", "R1"));
+        machine.Transitions.Add(new Transition("S1", "S4", "R2"));
+        machine.Transitions.Add(new Transition("S0", "S2", "R3"));
+        machine.Transitions.Add(new Transition("S2", "S4", "R4"));
+        machine.Transitions.Add(new Transition("S0", "S3", "R5"));
+        machine.Transitions.Add(new Transition("S3", "S4", "R6"));
+
+        var selected = new HashSet<string> { "S4" };
+
+        var result = new PathFilter(machine, selected).Filter();
+
+        Assert.Equal(5, result.States.Count);
+        Assert.Contains("S0", result.States.Keys);
+        Assert.Contains("S1", result.States.Keys);
+        Assert.Contains("S2", result.States.Keys);
+        Assert.Contains("S3", result.States.Keys);
+        Assert.Contains("S4", result.States.Keys);
+        Assert.Equal(6, result.Transitions.Count);
+    }
+
+    #endregion
+
+    #region Cycles
+
+    [Fact]
+    public void Filter_CycleInGraph_DoesNotInfiniteLoop()
+    {
+        // S0 -> S1 -> S2 (selected)
+        // S1 -> S0 (back edge / cycle)
+        var machine = new StateMachine();
+        machine.AddOrUpdateState("S0", new State());
+        machine.AddOrUpdateState("S1", new State());
+        machine.AddOrUpdateState("S2", new State());
+        machine.StartingStateId = "S0";
+        machine.Transitions.Add(new Transition("S0", "S1", "R1"));
+        machine.Transitions.Add(new Transition("S1", "S2", "R2"));
+        machine.Transitions.Add(new Transition("S1", "S0", "R3"));
+
+        var selected = new HashSet<string> { "S2" };
+
+        var result = new PathFilter(machine, selected).Filter();
+
+        Assert.Equal(3, result.States.Count);
+        Assert.Contains("S0", result.States.Keys);
+        Assert.Contains("S1", result.States.Keys);
+        Assert.Contains("S2", result.States.Keys);
+        // 3 transitions: S0->S1, S1->S2, and back edge S1->S0
+        // (back edge included because both endpoints are path states)
+        Assert.Equal(3, result.Transitions.Count);
+    }
+
+    #endregion
+
+    #region No Matches
+
+    [Fact]
+    public void Filter_NoSelectedStates_ReturnsEmptyMachine()
+    {
+        var machine = new StateMachine();
+        machine.AddOrUpdateState("S0", new State());
+        machine.AddOrUpdateState("S1", new State());
+        machine.StartingStateId = "S0";
+        machine.Transitions.Add(new Transition("S0", "S1", "R1"));
+
+        var selected = new HashSet<string>();
+
+        var result = new PathFilter(machine, selected).Filter();
+
+        Assert.Empty(result.States);
+        Assert.Empty(result.Transitions);
+        Assert.Null(result.StartingStateId);
+    }
+
+    [Fact]
+    public void Filter_SelectedStateNotReachable_ReturnsEmptyMachine()
+    {
+        // S0 -> S1, S2 is disconnected but selected
+        var machine = new StateMachine();
+        machine.AddOrUpdateState("S0", new State());
+        machine.AddOrUpdateState("S1", new State());
+        machine.AddOrUpdateState("S2", new State());
+        machine.StartingStateId = "S0";
+        machine.Transitions.Add(new Transition("S0", "S1", "R1"));
+
+        var selected = new HashSet<string> { "S2" };
+
+        var result = new PathFilter(machine, selected).Filter();
+
+        Assert.Empty(result.States);
+        Assert.Empty(result.Transitions);
+    }
+
+    #endregion
+
+    #region Starting State Inclusion
+
+    [Fact]
+    public void Filter_StartingStateIsSelected_IncludesOnlyStartingState()
+    {
+        var machine = new StateMachine();
+        machine.AddOrUpdateState("S0", new State());
+        machine.AddOrUpdateState("S1", new State());
+        machine.StartingStateId = "S0";
+        machine.Transitions.Add(new Transition("S0", "S1", "R1"));
+
+        var selected = new HashSet<string> { "S0" };
+
+        var result = new PathFilter(machine, selected).Filter();
+
+        Assert.Single(result.States);
+        Assert.Contains("S0", result.States.Keys);
+        Assert.Equal("S0", result.StartingStateId);
+        Assert.Empty(result.Transitions);
+    }
+
+    [Fact]
+    public void Filter_StartingStateAlwaysIncluded_WhenPathExists()
+    {
+        // S0 -> S1 -> S2 (selected)
+        var machine = new StateMachine();
+        machine.AddOrUpdateState("S0", new State());
+        machine.AddOrUpdateState("S1", new State());
+        machine.AddOrUpdateState("S2", new State());
+        machine.StartingStateId = "S0";
+        machine.Transitions.Add(new Transition("S0", "S1", "R1"));
+        machine.Transitions.Add(new Transition("S1", "S2", "R2"));
+
+        var selected = new HashSet<string> { "S2" };
+
+        var result = new PathFilter(machine, selected).Filter();
+
+        Assert.Contains("S0", result.States.Keys);
+        Assert.Equal("S0", result.StartingStateId);
+    }
+
+    #endregion
+
+    #region States Not on Path Excluded
+
+    [Fact]
+    public void Filter_StatesNotOnPath_AreExcluded()
+    {
+        // S0 -> S1 -> S2 (selected)
+        // S0 -> S3 (dead end, not selected)
+        // S5 is disconnected
+        var machine = new StateMachine();
+        machine.AddOrUpdateState("S0", new State());
+        machine.AddOrUpdateState("S1", new State());
+        machine.AddOrUpdateState("S2", new State());
+        machine.AddOrUpdateState("S3", new State());
+        machine.AddOrUpdateState("S5", new State());
+        machine.StartingStateId = "S0";
+        machine.Transitions.Add(new Transition("S0", "S1", "R1"));
+        machine.Transitions.Add(new Transition("S1", "S2", "R2"));
+        machine.Transitions.Add(new Transition("S0", "S3", "R3"));
+
+        var selected = new HashSet<string> { "S2" };
+
+        var result = new PathFilter(machine, selected).Filter();
+
+        Assert.DoesNotContain("S3", result.States.Keys);
+        Assert.DoesNotContain("S5", result.States.Keys);
+        Assert.Equal(3, result.States.Count);
+    }
+
+    #endregion
+
+    #region Preserves State Data
+
+    [Fact]
+    public void Filter_PreservesStateVariablesAndAttributes()
+    {
+        var machine = new StateMachine();
+        var s0 = new State();
+        s0.Variables["Status"] = "Pending";
+        var s1 = new State();
+        s1.Variables["Status"] = "Approved";
+        s1.Attributes["ranking"] = "high";
+        machine.AddOrUpdateState("S0", s0);
+        machine.AddOrUpdateState("S1", s1);
+        machine.StartingStateId = "S0";
+        machine.Transitions.Add(new Transition("S0", "S1", "R1"));
+
+        var selected = new HashSet<string> { "S1" };
+
+        var result = new PathFilter(machine, selected).Filter();
+
+        Assert.Equal("Pending", result.States["S0"].Variables["Status"]);
+        Assert.Equal("Approved", result.States["S1"].Variables["Status"]);
+        Assert.Equal("high", result.States["S1"].Attributes["ranking"]);
+    }
+
+    #endregion
+}

--- a/src/StateMaker.Tests/TestBatteryTests.cs
+++ b/src/StateMaker.Tests/TestBatteryTests.cs
@@ -1,9 +1,22 @@
 using System.Globalization;
+using Xunit.Abstractions;
 
 namespace StateMaker.Tests;
 
+// NOTE: Intermittent failures have been observed in RunSingle_ReverseGenerated_PassesAllOracles
+// during full test suite runs. The failure could not be reproduced in isolation or in five
+// consecutive full suite runs. The most likely cause is Oracle 6 (performance heuristic,
+// 100ms/state threshold) being sensitive to system load during parallel test execution.
+// Pay attention to any recurrence and note the failure reason when it happens.
+// See docs/test/test-battery-observations.md for potential mitigations under consideration.
 public class TestBatteryTests
 {
+    private readonly ITestOutputHelper _output;
+
+    public TestBatteryTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
     #region 3.22 — Test Case Generator Verification
 
     [Fact]
@@ -224,6 +237,9 @@ public class TestBatteryTests
     {
         var result = TestBatteryExecutor.Run(definition, TimeSpan.FromSeconds(5));
 
+        if (!result.Passed)
+            _output.WriteLine($"FAILURE: {definition.Name} — {result.FailureReason} (states={result.StateCount.ToString(CultureInfo.InvariantCulture)}, transitions={result.TransitionCount.ToString(CultureInfo.InvariantCulture)}, elapsed={result.ElapsedTime.TotalMilliseconds.ToString("F1", CultureInfo.InvariantCulture)}ms)");
+
         Assert.True(result.Passed, $"{definition.Name}: {result.FailureReason}");
     }
 
@@ -407,6 +423,9 @@ public class TestBatteryTests
     public void RunSingle_ReverseGenerated_PassesAllOracles(BuildDefinition definition)
     {
         var result = TestBatteryExecutor.Run(definition, TimeSpan.FromSeconds(5));
+
+        if (!result.Passed)
+            _output.WriteLine($"FAILURE: {definition.Name} — {result.FailureReason} (states={result.StateCount.ToString(CultureInfo.InvariantCulture)}, transitions={result.TransitionCount.ToString(CultureInfo.InvariantCulture)}, elapsed={result.ElapsedTime.TotalMilliseconds.ToString("F1", CultureInfo.InvariantCulture)}ms)");
 
         Assert.True(result.Passed, $"{definition.Name}: {result.FailureReason}");
     }

--- a/src/StateMaker/PathFilter.cs
+++ b/src/StateMaker/PathFilter.cs
@@ -1,0 +1,115 @@
+namespace StateMaker;
+
+public class PathFilter
+{
+    private readonly StateMachine _stateMachine;
+    private readonly HashSet<string> _selectedStateIds;
+
+    public PathFilter(StateMachine stateMachine, HashSet<string> selectedStateIds)
+    {
+        _stateMachine = stateMachine;
+        _selectedStateIds = selectedStateIds;
+    }
+
+    public StateMachine Filter()
+    {
+        if (_selectedStateIds.Count == 0 || _stateMachine.StartingStateId is null)
+            return new StateMachine();
+
+        // Build forward and reverse adjacency lists
+        var forwardAdj = new Dictionary<string, List<Transition>>();
+        var reverseAdj = new Dictionary<string, List<Transition>>();
+        foreach (var transition in _stateMachine.Transitions)
+        {
+            if (!forwardAdj.ContainsKey(transition.SourceStateId))
+                forwardAdj[transition.SourceStateId] = new List<Transition>();
+            forwardAdj[transition.SourceStateId].Add(transition);
+
+            if (!reverseAdj.ContainsKey(transition.TargetStateId))
+                reverseAdj[transition.TargetStateId] = new List<Transition>();
+            reverseAdj[transition.TargetStateId].Add(transition);
+        }
+
+        // Forward BFS from starting state, stopping at selected states
+        var forwardReachable = new HashSet<string>();
+        var reachedSelected = new HashSet<string>();
+        var queue = new Queue<string>();
+
+        queue.Enqueue(_stateMachine.StartingStateId);
+        forwardReachable.Add(_stateMachine.StartingStateId);
+
+        while (queue.Count > 0)
+        {
+            var current = queue.Dequeue();
+
+            if (_selectedStateIds.Contains(current))
+            {
+                reachedSelected.Add(current);
+                continue;
+            }
+
+            if (!forwardAdj.TryGetValue(current, out var transitions))
+                continue;
+
+            foreach (var transition in transitions)
+            {
+                if (forwardReachable.Add(transition.TargetStateId))
+                {
+                    queue.Enqueue(transition.TargetStateId);
+                }
+            }
+        }
+
+        if (reachedSelected.Count == 0)
+            return new StateMachine();
+
+        // Reverse BFS from reached selected states, only visiting forward-reachable states
+        var pathStates = new HashSet<string>();
+        queue.Clear();
+
+        foreach (var selectedId in reachedSelected)
+        {
+            if (pathStates.Add(selectedId))
+                queue.Enqueue(selectedId);
+        }
+
+        while (queue.Count > 0)
+        {
+            var current = queue.Dequeue();
+
+            if (!reverseAdj.TryGetValue(current, out var reverseTransitions))
+                continue;
+
+            foreach (var transition in reverseTransitions)
+            {
+                var predecessor = transition.SourceStateId;
+                if (forwardReachable.Contains(predecessor)
+                    && !_selectedStateIds.Contains(predecessor)
+                    && pathStates.Add(predecessor))
+                {
+                    queue.Enqueue(predecessor);
+                }
+            }
+        }
+
+        // Build result machine with states on path and their connecting transitions
+        var result = new StateMachine();
+        foreach (var stateId in pathStates)
+        {
+            result.AddOrUpdateState(stateId, _stateMachine.States[stateId]);
+        }
+        result.StartingStateId = _stateMachine.StartingStateId;
+
+        foreach (var transition in _stateMachine.Transitions)
+        {
+            if (pathStates.Contains(transition.SourceStateId)
+                && pathStates.Contains(transition.TargetStateId)
+                && !_selectedStateIds.Contains(transition.SourceStateId))
+            {
+                result.Transitions.Add(transition);
+            }
+        }
+
+        return result;
+    }
+}

--- a/tasks/tasks-state-filtering.md
+++ b/tasks/tasks-state-filtering.md
@@ -86,14 +86,14 @@ All tests must pass before moving on to the next sub-task.
   - [x] 3.6 Add tests in `FilterEngineTests.cs`: single rule match, no matches, multiple rules with attribute merging, condition referencing state ID, expression evaluation errors
   - [x] 3.7 Run tests and confirm all pass
 
-- [ ] 4.0 Create path traversal filter (forward reachability from starting state to selected states)
-  - [ ] 4.1 Create `PathFilter` class that accepts a `StateMachine` and a set of selected state IDs
-  - [ ] 4.2 Implement forward reachability: find all paths from starting state to any selected state using BFS/DFS
-  - [ ] 4.3 Produce a new `StateMachine` containing only the states on those paths and their connecting transitions
-  - [ ] 4.4 Always include the starting state if any path exists to a selected state
-  - [ ] 4.5 Return an empty state machine (no states, no transitions) if no states match the filter
-  - [ ] 4.6 Add tests in `PathFilterTests.cs`: linear chain, branching paths, cycles, no matches yields empty machine, starting state inclusion, states not on path excluded
-  - [ ] 4.7 Run tests and confirm all pass
+- [x] 4.0 Create path traversal filter (forward reachability from starting state to selected states)
+  - [x] 4.1 Create `PathFilter` class that accepts a `StateMachine` and a set of selected state IDs
+  - [x] 4.2 Implement forward reachability: find all paths from starting state to any selected state using BFS/DFS
+  - [x] 4.3 Produce a new `StateMachine` containing only the states on those paths and their connecting transitions
+  - [x] 4.4 Always include the starting state if any path exists to a selected state
+  - [x] 4.5 Return an empty state machine (no states, no transitions) if no states match the filter
+  - [x] 4.6 Add tests in `PathFilterTests.cs`: linear chain, branching paths, cycles, no matches yields empty machine, starting state inclusion, states not on path excluded
+  - [x] 4.7 Run tests and confirm all pass
 
 - [ ] 5.0 Update exporters to render attributes (visually distinguished from variables)
   - [ ] 5.1 Update `DotExporter` to include attributes in node labels, visually separated from variables (e.g., with a divider line or prefix)


### PR DESCRIPTION
## Summary
- Implement PathFilter class using forward BFS from starting state to selected states, then reverse BFS to capture all states on any path -- correctly handling convergent branches where multiple paths lead to the same selected state
- Add 16 tests in PathFilterTests covering linear chains, branching, convergent paths (5 variations), cycles, no-match edge cases, starting state inclusion, and state data preservation
- Add ITestOutputHelper to TestBatteryTests to capture detailed failure reasons (definition name, failure reason, state/transition counts, elapsed time) so intermittent failures are not lost in truncated output
- Document observed intermittent failure in RunSingle_ReverseGenerated_PassesAllOracles and record potential mitigations in docs/test/test-battery-observations.md, marked as proposals only
- Mark task 4.0 complete in task list

## Test plan
- [x] All 792 tests pass (dotnet test)
- [ ] Verify PathFilter correctly filters linear, branching, convergent, and cyclic state machines
- [ ] Verify intermittent failure details would be captured if recurrence happens

Generated with Claude Code