### PR TITLE
Fix path traversal and add filter file format docs

### DIFF
--- a/src/StateMaker/PathFilter.cs
+++ b/src/StateMaker/PathFilter.cs
@@ -30,7 +30,7 @@ public class PathFilter
             reverseAdj[transition.TargetStateId].Add(transition);
         }
 
-        // Forward BFS from starting state, stopping at selected states
+        // Forward BFS from starting state to find all reachable states
         var forwardReachable = new HashSet<string>();
         var reachedSelected = new HashSet<string>();
         var queue = new Queue<string>();
@@ -43,10 +43,7 @@ public class PathFilter
             var current = queue.Dequeue();
 
             if (_selectedStateIds.Contains(current))
-            {
                 reachedSelected.Add(current);
-                continue;
-            }
 
             if (!forwardAdj.TryGetValue(current, out var transitions))
                 continue;
@@ -63,7 +60,9 @@ public class PathFilter
         if (reachedSelected.Count == 0)
             return new StateMachine();
 
-        // Reverse BFS from reached selected states, only visiting forward-reachable states
+        // Reverse BFS from reached selected states, only visiting forward-reachable states.
+        // Selected states are already seeded in pathStates, so the check on predecessors
+        // skips them to avoid redundant processing (they are already included).
         var pathStates = new HashSet<string>();
         queue.Clear();
 
@@ -103,8 +102,7 @@ public class PathFilter
         foreach (var transition in _stateMachine.Transitions)
         {
             if (pathStates.Contains(transition.SourceStateId)
-                && pathStates.Contains(transition.TargetStateId)
-                && !_selectedStateIds.Contains(transition.SourceStateId))
+                && pathStates.Contains(transition.TargetStateId))
             {
                 result.Transitions.Add(transition);
             }


### PR DESCRIPTION
## Summary
- Fix PathFilter bug where forward BFS stopped at selected states, preventing discovery of selected states reachable only through other selected states (e.g., S0 -> S2 -> S3 [selected] -> S4 [selected] would miss S4)
- Fix related bug where transitions from selected states were incorrectly excluded from results, even when both endpoints were on valid paths
- Add Filter Definition File Format section to console usage docs covering JSON structure, validation rules, reserved `_stateId` variable, and attribute merging

## Test plan
- [x] 3 new PathFilter tests: starting state selected with other reachable, two selected in sequence, selected reachable only through another selected
- [x] All 19 PathFilter tests pass (including all pre-existing tests for linear chains, branching, convergent paths, cycles, no matches, state exclusion)
- [x] All 832 tests pass
- [x] Manual verification with user-provided sample machine and filter files

Generated with [Claude Code](https://claude.com/claude-code)