### PR TITLE
Handle undefined variables in rule conditions

### DIFF
--- a/src/StateMaker.Tests/ExpressionEvaluatorTests.cs
+++ b/src/StateMaker.Tests/ExpressionEvaluatorTests.cs
@@ -455,4 +455,53 @@ public class ExpressionEvaluatorTests
     }
 
     #endregion
+
+    #region EvaluateBooleanLenient — Undefined Parameters as Null
+
+    [Fact]
+    public void EvaluateBooleanLenient_UndefinedEqualsString_ReturnsFalse()
+    {
+        // null == 'Action1' → false
+        var result = _evaluator.EvaluateBooleanLenient(
+            "name == 'Action1'", Vars());
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void EvaluateBooleanLenient_UndefinedNotEqualString_ReturnsTrue()
+    {
+        // null != 'done' → true
+        var result = _evaluator.EvaluateBooleanLenient(
+            "buy != 'done'", Vars());
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void EvaluateBooleanLenient_CompoundWithUndefined_ReturnsCorrectly()
+    {
+        // Defined variables evaluate normally, undefined treated as null
+        var result = _evaluator.EvaluateBooleanLenient(
+            "displayed != 'options' && step > 1 && cart == 'empty' && buy != 'done'",
+            Vars(("displayed", "fish"), ("step", 2), ("cart", "empty")));
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void EvaluateBooleanLenient_AllDefined_WorksNormally()
+    {
+        var result = _evaluator.EvaluateBooleanLenient(
+            "[Status] == 'Pending' && [Count] < 10",
+            Vars(("Status", "Pending"), ("Count", 5)));
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void EvaluateBoolean_Strict_UndefinedVariable_StillThrows()
+    {
+        // The strict EvaluateBoolean should still throw for undefined params
+        Assert.Throws<ExpressionEvaluationException>(() =>
+            _evaluator.EvaluateBoolean("buy != 'done'", Vars()));
+    }
+
+    #endregion
 }

--- a/src/StateMaker.Tests/sampledata/build_20deep_linear.json
+++ b/src/StateMaker.Tests/sampledata/build_20deep_linear.json
@@ -1,0 +1,18 @@
+{
+  "initialState": {
+    "step": 0
+  },
+  "rules": [
+    {
+      "name": "Advance",
+      "condition": "step >= 0",
+      "transformations": {
+        "step": "step + 1"
+      }
+    }
+  ],
+  "config": {
+    "maxDepth": 20,
+    "explorationStrategy": "BreadthFirstSearch"
+  }
+}

--- a/src/StateMaker.Tests/sampledata/build_2branch_loopback2_10deep.json
+++ b/src/StateMaker.Tests/sampledata/build_2branch_loopback2_10deep.json
@@ -1,0 +1,33 @@
+{
+  "initialState": {
+    "step": 0
+  },
+  "rules": [
+    {
+      "name": "advance",
+      "condition": "step >= 0",
+      "transformations": {
+        "step": "step + 1"
+      }
+    },
+    {
+      "name": "loop back 3",
+      "condition": "step >= 3",
+      "transformations": {
+        "step": "step -2"
+      }
+    },
+    {
+      "name": "birth branch",
+      "condition": "step == 0",
+      "transformations": {
+        "step": "step + 1",
+        "branch": "'new branch'"
+      }
+    }
+  ],
+  "config": {
+    "maxDepth": 10,
+    "explorationStrategy": "BreadthFirstSearch"
+  }
+}

--- a/src/StateMaker.Tests/sampledata/build_2branch_merge_10deep.json
+++ b/src/StateMaker.Tests/sampledata/build_2branch_merge_10deep.json
@@ -1,0 +1,58 @@
+{
+  "initialState": {
+    "step": 0,
+    "branch": "trunk"
+  },
+  "rules": [
+    {
+      "name": "take branch1",
+      "condition": "step >= 0 && branch == 'trunk'",
+      "transformations": {
+        "step": "step + 1",
+        "branch": "'branch1'"
+      }
+    },
+    {
+      "name": "take branch2",
+      "condition": "step >= 0 && branch == 'trunk'",
+      "transformations": {
+        "step": "step + 1",
+        "branch": "'branch2'"
+      }
+    },
+    {
+      "name": "add branch1",
+      "condition": "step >= 0 && branch == 'branch1'",
+      "transformations": {
+        "step": "step + 1"
+      }
+    },
+    {
+      "name": "add branch2",
+      "condition": "step >= 0 && branch == 'branch2'",
+      "transformations": {
+        "step": "step + 1"
+      }
+    },
+    {
+      "name": "merge branch1",
+      "condition": "step > 1 && branch == 'branch1'",
+      "transformations": {
+        "step": "step + 1",
+        "branch": "'trunk'"
+      }
+    },
+    {
+      "name": "merge branch2",
+      "condition": "step > 1 && branch == 'branch2'",
+      "transformations": {
+        "step": "step + 1",
+        "branch": "'trunk'"
+      }
+    }
+  ],
+  "config": {
+    "maxDepth": 10,
+    "explorationStrategy": "BreadthFirstSearch"
+  }
+}

--- a/src/StateMaker.Tests/sampledata/build_5actions_5deep.json
+++ b/src/StateMaker.Tests/sampledata/build_5actions_5deep.json
@@ -1,0 +1,46 @@
+{
+  "initialState": {
+    "step": 0
+  },
+  "rules": [
+    {
+      "name": "Action1",
+      "condition": "step >= 0",
+      "transformations": {
+        "step": "step + 1"
+      }
+    },
+    {
+      "name": "Action2",
+      "condition": "step >= 0",
+      "transformations": {
+        "step": "step + 1"
+      }
+    },
+    {
+      "name": "Action3",
+      "condition": "step >= 0",
+      "transformations": {
+        "step": "step + 1"
+      }
+    },
+    {
+      "name": "Action4",
+      "condition": "step >= 0",
+      "transformations": {
+        "step": "step + 1"
+      }
+    },
+    {
+      "name": "Action5",
+      "condition": "step >= 0",
+      "transformations": {
+        "step": "step + 1"
+      }
+    }
+  ],
+  "config": {
+    "maxDepth": 5,
+    "explorationStrategy": "BreadthFirstSearch"
+  }
+}

--- a/src/StateMaker.Tests/sampledata/build_5high_5deep_tree.json
+++ b/src/StateMaker.Tests/sampledata/build_5high_5deep_tree.json
@@ -1,0 +1,91 @@
+{
+  "initialState": {
+    "step": 0
+  },
+  "rules": [
+    {
+      "name": "Action1",
+      "condition": "step = 0",
+      "transformations": {
+        "step": "step + 1",
+        "name": "'Action1'"
+      }
+    },
+    {
+      "name": "Action2",
+      "condition": "step = 0",
+      "transformations": {
+        "step": "step + 1",
+        "name": "'Action2'"
+      }
+    },
+    {
+      "name": "Action3",
+      "condition": "step = 0",
+      "transformations": {
+        "step": "step + 1",
+        "name": "'Action3'"
+      }
+    },
+    {
+      "name": "Action4",
+      "condition": "step = 0",
+      "transformations": {
+        "step": "step + 1",
+        "name": "'Action4'"
+      }
+    },
+    {
+      "name": "Action5",
+      "condition": "step = 0",
+      "transformations": {
+        "step": "step + 1",
+        "name": "'Action5'"
+      }
+     },
+    {
+      "name": "Action1",
+      "condition": "step >= 0 && name == 'Action1'",
+      "transformations": {
+        "step": "step + 1",
+        "name": "'Action1'"
+      }
+     },
+    {
+      "name": "Action2",
+      "condition": "step >= 0 && name == 'Action2'",
+      "transformations": {
+        "step": "step + 1",
+        "name": "'Action2'"
+      }
+     },
+    {
+      "name": "Action3",
+      "condition": "step >= 0 && name == 'Action3'",
+      "transformations": {
+        "step": "step + 1",
+        "name": "'Action3'"
+      }
+     },
+    {
+      "name": "Action4",
+      "condition": "step >= 0 && name == 'Action4'",
+      "transformations": {
+        "step": "step + 1",
+        "name": "'Action4'"
+      }
+     },
+    {
+      "name": "Action5",
+      "condition": "step >= 0 && name == 'Action5'",
+      "transformations": {
+        "step": "step + 1",
+        "name": "'Action5'"
+      }
+     }
+  ],
+  "config": {
+    "maxDepth": 5,
+    "explorationStrategy": "BreadthFirstSearch"
+  }
+}

--- a/src/StateMaker.Tests/sampledata/build_cart_3options_select_buy.json
+++ b/src/StateMaker.Tests/sampledata/build_cart_3options_select_buy.json
@@ -1,0 +1,62 @@
+{
+  "initialState": {
+    "step": 0,
+    "cart": "empty"
+  },
+  "rules": [
+    {
+      "name": "present options",
+      "condition": "step == 0",
+      "transformations": {
+        "step": "step + 1",
+        "displayed": "'options'"
+      }
+    },
+    {
+      "name": "pick option fish",
+      "condition": "displayed == 'options'",
+      "transformations": {
+        "step": "step + 1",
+        "displayed": "'fish'"
+      }
+    },
+    {
+      "name": "pick option salad",
+      "condition": "displayed == 'options'",
+      "transformations": {
+        "step": "step + 1",
+        "displayed": "'salad'"
+      }
+    },
+    {
+      "name": "pick option beef",
+      "condition": "displayed == 'options'",
+      "transformations": {
+        "step": "step + 1",
+        "displayed": "'beef'"
+      }
+    },
+    {
+      "name": "order selected",
+      "condition": "displayed != 'options' && step > 1 && cart == 'empty' && buy != 'done'",
+      "transformations": {
+        "step": "step + 1",
+        "cart": "displayed",
+        "displayed": "'cart'"
+      }
+    },
+    {
+      "name": "buy",
+      "condition": "displayed == 'cart' && displayed != 'options' && cart != 'empty'",
+      "transformations": {
+        "step": "step + 1",
+        "cart": "'empty'",
+        "buy" : "'done'"
+      }
+     }
+  ],
+  "config": {
+    "maxDepth": 10,
+    "explorationStrategy": "BreadthFirstSearch"
+  }
+}

--- a/src/StateMaker.Tests/sampledata/build_loopback2_10deep.json
+++ b/src/StateMaker.Tests/sampledata/build_loopback2_10deep.json
@@ -1,0 +1,25 @@
+{
+  "initialState": {
+    "step": 0
+  },
+  "rules": [
+    {
+      "name": "advance",
+      "condition": "step >= 0",
+      "transformations": {
+        "step": "step + 1"
+      }
+    },
+    {
+      "name": "loop back 2",
+      "condition": "step >= 2",
+      "transformations": {
+        "step": "step -2"
+      }
+    }
+  ],
+  "config": {
+    "maxDepth": 10,
+    "explorationStrategy": "BreadthFirstSearch"
+  }
+}

--- a/src/StateMaker.Tests/sampledata/build_loopback3_12deep.json
+++ b/src/StateMaker.Tests/sampledata/build_loopback3_12deep.json
@@ -1,0 +1,25 @@
+{
+  "initialState": {
+    "step": 0
+  },
+  "rules": [
+    {
+      "name": "advance",
+      "condition": "step >= 0",
+      "transformations": {
+        "step": "step + 1"
+      }
+    },
+    {
+      "name": "loop back 3",
+      "condition": "step >= 3",
+      "transformations": {
+        "step": "step -3"
+      }
+    }
+  ],
+  "config": {
+    "maxDepth": 12,
+    "explorationStrategy": "BreadthFirstSearch"
+  }
+}

--- a/src/StateMaker.Tests/sampledata/machine_20deep_linear.json
+++ b/src/StateMaker.Tests/sampledata/machine_20deep_linear.json
@@ -1,0 +1,170 @@
+{
+  "startingStateId": "S0",
+  "states": {
+    "S0": {
+      "step": 0
+    },
+    "S1": {
+      "step": 1
+    },
+    "S2": {
+      "step": 2
+    },
+    "S3": {
+      "step": 3
+    },
+    "S4": {
+      "step": 4
+    },
+    "S5": {
+      "step": 5
+    },
+    "S6": {
+      "step": 6
+    },
+    "S7": {
+      "step": 7
+    },
+    "S8": {
+      "step": 8
+    },
+    "S9": {
+      "step": 9
+    },
+    "S10": {
+      "step": 10
+    },
+    "S11": {
+      "step": 11
+    },
+    "S12": {
+      "step": 12
+    },
+    "S13": {
+      "step": 13
+    },
+    "S14": {
+      "step": 14
+    },
+    "S15": {
+      "step": 15
+    },
+    "S16": {
+      "step": 16
+    },
+    "S17": {
+      "step": 17
+    },
+    "S18": {
+      "step": 18
+    },
+    "S19": {
+      "step": 19
+    },
+    "S20": {
+      "step": 20
+    }
+  },
+  "transitions": [
+    {
+      "sourceStateId": "S0",
+      "targetStateId": "S1",
+      "ruleName": "Advance"
+    },
+    {
+      "sourceStateId": "S1",
+      "targetStateId": "S2",
+      "ruleName": "Advance"
+    },
+    {
+      "sourceStateId": "S2",
+      "targetStateId": "S3",
+      "ruleName": "Advance"
+    },
+    {
+      "sourceStateId": "S3",
+      "targetStateId": "S4",
+      "ruleName": "Advance"
+    },
+    {
+      "sourceStateId": "S4",
+      "targetStateId": "S5",
+      "ruleName": "Advance"
+    },
+    {
+      "sourceStateId": "S5",
+      "targetStateId": "S6",
+      "ruleName": "Advance"
+    },
+    {
+      "sourceStateId": "S6",
+      "targetStateId": "S7",
+      "ruleName": "Advance"
+    },
+    {
+      "sourceStateId": "S7",
+      "targetStateId": "S8",
+      "ruleName": "Advance"
+    },
+    {
+      "sourceStateId": "S8",
+      "targetStateId": "S9",
+      "ruleName": "Advance"
+    },
+    {
+      "sourceStateId": "S9",
+      "targetStateId": "S10",
+      "ruleName": "Advance"
+    },
+    {
+      "sourceStateId": "S10",
+      "targetStateId": "S11",
+      "ruleName": "Advance"
+    },
+    {
+      "sourceStateId": "S11",
+      "targetStateId": "S12",
+      "ruleName": "Advance"
+    },
+    {
+      "sourceStateId": "S12",
+      "targetStateId": "S13",
+      "ruleName": "Advance"
+    },
+    {
+      "sourceStateId": "S13",
+      "targetStateId": "S14",
+      "ruleName": "Advance"
+    },
+    {
+      "sourceStateId": "S14",
+      "targetStateId": "S15",
+      "ruleName": "Advance"
+    },
+    {
+      "sourceStateId": "S15",
+      "targetStateId": "S16",
+      "ruleName": "Advance"
+    },
+    {
+      "sourceStateId": "S16",
+      "targetStateId": "S17",
+      "ruleName": "Advance"
+    },
+    {
+      "sourceStateId": "S17",
+      "targetStateId": "S18",
+      "ruleName": "Advance"
+    },
+    {
+      "sourceStateId": "S18",
+      "targetStateId": "S19",
+      "ruleName": "Advance"
+    },
+    {
+      "sourceStateId": "S19",
+      "targetStateId": "S20",
+      "ruleName": "Advance"
+    }
+  ]
+}

--- a/src/StateMaker.Tests/sampledata/machine_2branch_loopback2_10deep.json
+++ b/src/StateMaker.Tests/sampledata/machine_2branch_loopback2_10deep.json
@@ -1,0 +1,250 @@
+{
+  "startingStateId": "S0",
+  "states": {
+    "S0": {
+      "step": 0
+    },
+    "S1": {
+      "step": 1
+    },
+    "S2": {
+      "step": 1,
+      "branch": "new branch"
+    },
+    "S3": {
+      "step": 2
+    },
+    "S4": {
+      "step": 2,
+      "branch": "new branch"
+    },
+    "S5": {
+      "step": 3
+    },
+    "S6": {
+      "step": 3,
+      "branch": "new branch"
+    },
+    "S7": {
+      "step": 4
+    },
+    "S8": {
+      "step": 4,
+      "branch": "new branch"
+    },
+    "S9": {
+      "step": 5
+    },
+    "S10": {
+      "step": 5,
+      "branch": "new branch"
+    },
+    "S11": {
+      "step": 6
+    },
+    "S12": {
+      "step": 6,
+      "branch": "new branch"
+    },
+    "S13": {
+      "step": 7
+    },
+    "S14": {
+      "step": 7,
+      "branch": "new branch"
+    },
+    "S15": {
+      "step": 8
+    },
+    "S16": {
+      "step": 8,
+      "branch": "new branch"
+    },
+    "S17": {
+      "step": 9
+    },
+    "S18": {
+      "step": 9,
+      "branch": "new branch"
+    },
+    "S19": {
+      "step": 10
+    },
+    "S20": {
+      "step": 10,
+      "branch": "new branch"
+    }
+  },
+  "transitions": [
+    {
+      "sourceStateId": "S0",
+      "targetStateId": "S1",
+      "ruleName": "advance"
+    },
+    {
+      "sourceStateId": "S0",
+      "targetStateId": "S2",
+      "ruleName": "birth branch"
+    },
+    {
+      "sourceStateId": "S1",
+      "targetStateId": "S3",
+      "ruleName": "advance"
+    },
+    {
+      "sourceStateId": "S2",
+      "targetStateId": "S4",
+      "ruleName": "advance"
+    },
+    {
+      "sourceStateId": "S3",
+      "targetStateId": "S5",
+      "ruleName": "advance"
+    },
+    {
+      "sourceStateId": "S4",
+      "targetStateId": "S6",
+      "ruleName": "advance"
+    },
+    {
+      "sourceStateId": "S5",
+      "targetStateId": "S7",
+      "ruleName": "advance"
+    },
+    {
+      "sourceStateId": "S5",
+      "targetStateId": "S1",
+      "ruleName": "loop back 3"
+    },
+    {
+      "sourceStateId": "S6",
+      "targetStateId": "S8",
+      "ruleName": "advance"
+    },
+    {
+      "sourceStateId": "S6",
+      "targetStateId": "S2",
+      "ruleName": "loop back 3"
+    },
+    {
+      "sourceStateId": "S7",
+      "targetStateId": "S9",
+      "ruleName": "advance"
+    },
+    {
+      "sourceStateId": "S7",
+      "targetStateId": "S3",
+      "ruleName": "loop back 3"
+    },
+    {
+      "sourceStateId": "S8",
+      "targetStateId": "S10",
+      "ruleName": "advance"
+    },
+    {
+      "sourceStateId": "S8",
+      "targetStateId": "S4",
+      "ruleName": "loop back 3"
+    },
+    {
+      "sourceStateId": "S9",
+      "targetStateId": "S11",
+      "ruleName": "advance"
+    },
+    {
+      "sourceStateId": "S9",
+      "targetStateId": "S5",
+      "ruleName": "loop back 3"
+    },
+    {
+      "sourceStateId": "S10",
+      "targetStateId": "S12",
+      "ruleName": "advance"
+    },
+    {
+      "sourceStateId": "S10",
+      "targetStateId": "S6",
+      "ruleName": "loop back 3"
+    },
+    {
+      "sourceStateId": "S11",
+      "targetStateId": "S13",
+      "ruleName": "advance"
+    },
+    {
+      "sourceStateId": "S11",
+      "targetStateId": "S7",
+      "ruleName": "loop back 3"
+    },
+    {
+      "sourceStateId": "S12",
+      "targetStateId": "S14",
+      "ruleName": "advance"
+    },
+    {
+      "sourceStateId": "S12",
+      "targetStateId": "S8",
+      "ruleName": "loop back 3"
+    },
+    {
+      "sourceStateId": "S13",
+      "targetStateId": "S15",
+      "ruleName": "advance"
+    },
+    {
+      "sourceStateId": "S13",
+      "targetStateId": "S9",
+      "ruleName": "loop back 3"
+    },
+    {
+      "sourceStateId": "S14",
+      "targetStateId": "S16",
+      "ruleName": "advance"
+    },
+    {
+      "sourceStateId": "S14",
+      "targetStateId": "S10",
+      "ruleName": "loop back 3"
+    },
+    {
+      "sourceStateId": "S15",
+      "targetStateId": "S17",
+      "ruleName": "advance"
+    },
+    {
+      "sourceStateId": "S15",
+      "targetStateId": "S11",
+      "ruleName": "loop back 3"
+    },
+    {
+      "sourceStateId": "S16",
+      "targetStateId": "S18",
+      "ruleName": "advance"
+    },
+    {
+      "sourceStateId": "S16",
+      "targetStateId": "S12",
+      "ruleName": "loop back 3"
+    },
+    {
+      "sourceStateId": "S17",
+      "targetStateId": "S19",
+      "ruleName": "advance"
+    },
+    {
+      "sourceStateId": "S17",
+      "targetStateId": "S13",
+      "ruleName": "loop back 3"
+    },
+    {
+      "sourceStateId": "S18",
+      "targetStateId": "S20",
+      "ruleName": "advance"
+    },
+    {
+      "sourceStateId": "S18",
+      "targetStateId": "S14",
+      "ruleName": "loop back 3"
+    }
+  ]
+}

--- a/src/StateMaker.Tests/sampledata/machine_2branch_merge_10deep.json
+++ b/src/StateMaker.Tests/sampledata/machine_2branch_merge_10deep.json
@@ -1,0 +1,373 @@
+{
+  "startingStateId": "S0",
+  "states": {
+    "S0": {
+      "step": 0,
+      "branch": "trunk"
+    },
+    "S1": {
+      "step": 1,
+      "branch": "branch1"
+    },
+    "S2": {
+      "step": 1,
+      "branch": "branch2"
+    },
+    "S3": {
+      "step": 2,
+      "branch": "branch1"
+    },
+    "S4": {
+      "step": 2,
+      "branch": "branch2"
+    },
+    "S5": {
+      "step": 3,
+      "branch": "branch1"
+    },
+    "S6": {
+      "step": 3,
+      "branch": "trunk"
+    },
+    "S7": {
+      "step": 3,
+      "branch": "branch2"
+    },
+    "S8": {
+      "step": 4,
+      "branch": "branch1"
+    },
+    "S9": {
+      "step": 4,
+      "branch": "trunk"
+    },
+    "S10": {
+      "step": 4,
+      "branch": "branch2"
+    },
+    "S11": {
+      "step": 5,
+      "branch": "branch1"
+    },
+    "S12": {
+      "step": 5,
+      "branch": "trunk"
+    },
+    "S13": {
+      "step": 5,
+      "branch": "branch2"
+    },
+    "S14": {
+      "step": 6,
+      "branch": "branch1"
+    },
+    "S15": {
+      "step": 6,
+      "branch": "trunk"
+    },
+    "S16": {
+      "step": 6,
+      "branch": "branch2"
+    },
+    "S17": {
+      "step": 7,
+      "branch": "branch1"
+    },
+    "S18": {
+      "step": 7,
+      "branch": "trunk"
+    },
+    "S19": {
+      "step": 7,
+      "branch": "branch2"
+    },
+    "S20": {
+      "step": 8,
+      "branch": "branch1"
+    },
+    "S21": {
+      "step": 8,
+      "branch": "trunk"
+    },
+    "S22": {
+      "step": 8,
+      "branch": "branch2"
+    },
+    "S23": {
+      "step": 9,
+      "branch": "branch1"
+    },
+    "S24": {
+      "step": 9,
+      "branch": "trunk"
+    },
+    "S25": {
+      "step": 9,
+      "branch": "branch2"
+    },
+    "S26": {
+      "step": 10,
+      "branch": "branch1"
+    },
+    "S27": {
+      "step": 10,
+      "branch": "trunk"
+    },
+    "S28": {
+      "step": 10,
+      "branch": "branch2"
+    }
+  },
+  "transitions": [
+    {
+      "sourceStateId": "S0",
+      "targetStateId": "S1",
+      "ruleName": "take branch1"
+    },
+    {
+      "sourceStateId": "S0",
+      "targetStateId": "S2",
+      "ruleName": "take branch2"
+    },
+    {
+      "sourceStateId": "S1",
+      "targetStateId": "S3",
+      "ruleName": "add branch1"
+    },
+    {
+      "sourceStateId": "S2",
+      "targetStateId": "S4",
+      "ruleName": "add branch2"
+    },
+    {
+      "sourceStateId": "S3",
+      "targetStateId": "S5",
+      "ruleName": "add branch1"
+    },
+    {
+      "sourceStateId": "S3",
+      "targetStateId": "S6",
+      "ruleName": "merge branch1"
+    },
+    {
+      "sourceStateId": "S4",
+      "targetStateId": "S7",
+      "ruleName": "add branch2"
+    },
+    {
+      "sourceStateId": "S4",
+      "targetStateId": "S6",
+      "ruleName": "merge branch2"
+    },
+    {
+      "sourceStateId": "S5",
+      "targetStateId": "S8",
+      "ruleName": "add branch1"
+    },
+    {
+      "sourceStateId": "S5",
+      "targetStateId": "S9",
+      "ruleName": "merge branch1"
+    },
+    {
+      "sourceStateId": "S6",
+      "targetStateId": "S8",
+      "ruleName": "take branch1"
+    },
+    {
+      "sourceStateId": "S6",
+      "targetStateId": "S10",
+      "ruleName": "take branch2"
+    },
+    {
+      "sourceStateId": "S7",
+      "targetStateId": "S10",
+      "ruleName": "add branch2"
+    },
+    {
+      "sourceStateId": "S7",
+      "targetStateId": "S9",
+      "ruleName": "merge branch2"
+    },
+    {
+      "sourceStateId": "S8",
+      "targetStateId": "S11",
+      "ruleName": "add branch1"
+    },
+    {
+      "sourceStateId": "S8",
+      "targetStateId": "S12",
+      "ruleName": "merge branch1"
+    },
+    {
+      "sourceStateId": "S9",
+      "targetStateId": "S11",
+      "ruleName": "take branch1"
+    },
+    {
+      "sourceStateId": "S9",
+      "targetStateId": "S13",
+      "ruleName": "take branch2"
+    },
+    {
+      "sourceStateId": "S10",
+      "targetStateId": "S13",
+      "ruleName": "add branch2"
+    },
+    {
+      "sourceStateId": "S10",
+      "targetStateId": "S12",
+      "ruleName": "merge branch2"
+    },
+    {
+      "sourceStateId": "S11",
+      "targetStateId": "S14",
+      "ruleName": "add branch1"
+    },
+    {
+      "sourceStateId": "S11",
+      "targetStateId": "S15",
+      "ruleName": "merge branch1"
+    },
+    {
+      "sourceStateId": "S12",
+      "targetStateId": "S14",
+      "ruleName": "take branch1"
+    },
+    {
+      "sourceStateId": "S12",
+      "targetStateId": "S16",
+      "ruleName": "take branch2"
+    },
+    {
+      "sourceStateId": "S13",
+      "targetStateId": "S16",
+      "ruleName": "add branch2"
+    },
+    {
+      "sourceStateId": "S13",
+      "targetStateId": "S15",
+      "ruleName": "merge branch2"
+    },
+    {
+      "sourceStateId": "S14",
+      "targetStateId": "S17",
+      "ruleName": "add branch1"
+    },
+    {
+      "sourceStateId": "S14",
+      "targetStateId": "S18",
+      "ruleName": "merge branch1"
+    },
+    {
+      "sourceStateId": "S15",
+      "targetStateId": "S17",
+      "ruleName": "take branch1"
+    },
+    {
+      "sourceStateId": "S15",
+      "targetStateId": "S19",
+      "ruleName": "take branch2"
+    },
+    {
+      "sourceStateId": "S16",
+      "targetStateId": "S19",
+      "ruleName": "add branch2"
+    },
+    {
+      "sourceStateId": "S16",
+      "targetStateId": "S18",
+      "ruleName": "merge branch2"
+    },
+    {
+      "sourceStateId": "S17",
+      "targetStateId": "S20",
+      "ruleName": "add branch1"
+    },
+    {
+      "sourceStateId": "S17",
+      "targetStateId": "S21",
+      "ruleName": "merge branch1"
+    },
+    {
+      "sourceStateId": "S18",
+      "targetStateId": "S20",
+      "ruleName": "take branch1"
+    },
+    {
+      "sourceStateId": "S18",
+      "targetStateId": "S22",
+      "ruleName": "take branch2"
+    },
+    {
+      "sourceStateId": "S19",
+      "targetStateId": "S22",
+      "ruleName": "add branch2"
+    },
+    {
+      "sourceStateId": "S19",
+      "targetStateId": "S21",
+      "ruleName": "merge branch2"
+    },
+    {
+      "sourceStateId": "S20",
+      "targetStateId": "S23",
+      "ruleName": "add branch1"
+    },
+    {
+      "sourceStateId": "S20",
+      "targetStateId": "S24",
+      "ruleName": "merge branch1"
+    },
+    {
+      "sourceStateId": "S21",
+      "targetStateId": "S23",
+      "ruleName": "take branch1"
+    },
+    {
+      "sourceStateId": "S21",
+      "targetStateId": "S25",
+      "ruleName": "take branch2"
+    },
+    {
+      "sourceStateId": "S22",
+      "targetStateId": "S25",
+      "ruleName": "add branch2"
+    },
+    {
+      "sourceStateId": "S22",
+      "targetStateId": "S24",
+      "ruleName": "merge branch2"
+    },
+    {
+      "sourceStateId": "S23",
+      "targetStateId": "S26",
+      "ruleName": "add branch1"
+    },
+    {
+      "sourceStateId": "S23",
+      "targetStateId": "S27",
+      "ruleName": "merge branch1"
+    },
+    {
+      "sourceStateId": "S24",
+      "targetStateId": "S26",
+      "ruleName": "take branch1"
+    },
+    {
+      "sourceStateId": "S24",
+      "targetStateId": "S28",
+      "ruleName": "take branch2"
+    },
+    {
+      "sourceStateId": "S25",
+      "targetStateId": "S28",
+      "ruleName": "add branch2"
+    },
+    {
+      "sourceStateId": "S25",
+      "targetStateId": "S27",
+      "ruleName": "merge branch2"
+    }
+  ]
+}

--- a/src/StateMaker.Tests/sampledata/machine_5actions_5deep.json
+++ b/src/StateMaker.Tests/sampledata/machine_5actions_5deep.json
@@ -1,0 +1,150 @@
+{
+  "startingStateId": "S0",
+  "states": {
+    "S0": {
+      "step": 0
+    },
+    "S1": {
+      "step": 1
+    },
+    "S2": {
+      "step": 2
+    },
+    "S3": {
+      "step": 3
+    },
+    "S4": {
+      "step": 4
+    },
+    "S5": {
+      "step": 5
+    }
+  },
+  "transitions": [
+    {
+      "sourceStateId": "S0",
+      "targetStateId": "S1",
+      "ruleName": "Action1"
+    },
+    {
+      "sourceStateId": "S0",
+      "targetStateId": "S1",
+      "ruleName": "Action2"
+    },
+    {
+      "sourceStateId": "S0",
+      "targetStateId": "S1",
+      "ruleName": "Action3"
+    },
+    {
+      "sourceStateId": "S0",
+      "targetStateId": "S1",
+      "ruleName": "Action4"
+    },
+    {
+      "sourceStateId": "S0",
+      "targetStateId": "S1",
+      "ruleName": "Action5"
+    },
+    {
+      "sourceStateId": "S1",
+      "targetStateId": "S2",
+      "ruleName": "Action1"
+    },
+    {
+      "sourceStateId": "S1",
+      "targetStateId": "S2",
+      "ruleName": "Action2"
+    },
+    {
+      "sourceStateId": "S1",
+      "targetStateId": "S2",
+      "ruleName": "Action3"
+    },
+    {
+      "sourceStateId": "S1",
+      "targetStateId": "S2",
+      "ruleName": "Action4"
+    },
+    {
+      "sourceStateId": "S1",
+      "targetStateId": "S2",
+      "ruleName": "Action5"
+    },
+    {
+      "sourceStateId": "S2",
+      "targetStateId": "S3",
+      "ruleName": "Action1"
+    },
+    {
+      "sourceStateId": "S2",
+      "targetStateId": "S3",
+      "ruleName": "Action2"
+    },
+    {
+      "sourceStateId": "S2",
+      "targetStateId": "S3",
+      "ruleName": "Action3"
+    },
+    {
+      "sourceStateId": "S2",
+      "targetStateId": "S3",
+      "ruleName": "Action4"
+    },
+    {
+      "sourceStateId": "S2",
+      "targetStateId": "S3",
+      "ruleName": "Action5"
+    },
+    {
+      "sourceStateId": "S3",
+      "targetStateId": "S4",
+      "ruleName": "Action1"
+    },
+    {
+      "sourceStateId": "S3",
+      "targetStateId": "S4",
+      "ruleName": "Action2"
+    },
+    {
+      "sourceStateId": "S3",
+      "targetStateId": "S4",
+      "ruleName": "Action3"
+    },
+    {
+      "sourceStateId": "S3",
+      "targetStateId": "S4",
+      "ruleName": "Action4"
+    },
+    {
+      "sourceStateId": "S3",
+      "targetStateId": "S4",
+      "ruleName": "Action5"
+    },
+    {
+      "sourceStateId": "S4",
+      "targetStateId": "S5",
+      "ruleName": "Action1"
+    },
+    {
+      "sourceStateId": "S4",
+      "targetStateId": "S5",
+      "ruleName": "Action2"
+    },
+    {
+      "sourceStateId": "S4",
+      "targetStateId": "S5",
+      "ruleName": "Action3"
+    },
+    {
+      "sourceStateId": "S4",
+      "targetStateId": "S5",
+      "ruleName": "Action4"
+    },
+    {
+      "sourceStateId": "S4",
+      "targetStateId": "S5",
+      "ruleName": "Action5"
+    }
+  ]
+}

--- a/src/StateMaker.Tests/sampledata/machine_5high_5deep_tree.json
+++ b/src/StateMaker.Tests/sampledata/machine_5high_5deep_tree.json
@@ -1,0 +1,235 @@
+{
+  "startingStateId": "S0",
+  "states": {
+    "S0": {
+      "step": 0
+    },
+    "S1": {
+      "step": 1,
+      "name": "Action1"
+    },
+    "S2": {
+      "step": 1,
+      "name": "Action2"
+    },
+    "S3": {
+      "step": 1,
+      "name": "Action3"
+    },
+    "S4": {
+      "step": 1,
+      "name": "Action4"
+    },
+    "S5": {
+      "step": 1,
+      "name": "Action5"
+    },
+    "S6": {
+      "step": 2,
+      "name": "Action1"
+    },
+    "S7": {
+      "step": 2,
+      "name": "Action2"
+    },
+    "S8": {
+      "step": 2,
+      "name": "Action3"
+    },
+    "S9": {
+      "step": 2,
+      "name": "Action4"
+    },
+    "S10": {
+      "step": 2,
+      "name": "Action5"
+    },
+    "S11": {
+      "step": 3,
+      "name": "Action1"
+    },
+    "S12": {
+      "step": 3,
+      "name": "Action2"
+    },
+    "S13": {
+      "step": 3,
+      "name": "Action3"
+    },
+    "S14": {
+      "step": 3,
+      "name": "Action4"
+    },
+    "S15": {
+      "step": 3,
+      "name": "Action5"
+    },
+    "S16": {
+      "step": 4,
+      "name": "Action1"
+    },
+    "S17": {
+      "step": 4,
+      "name": "Action2"
+    },
+    "S18": {
+      "step": 4,
+      "name": "Action3"
+    },
+    "S19": {
+      "step": 4,
+      "name": "Action4"
+    },
+    "S20": {
+      "step": 4,
+      "name": "Action5"
+    },
+    "S21": {
+      "step": 5,
+      "name": "Action1"
+    },
+    "S22": {
+      "step": 5,
+      "name": "Action2"
+    },
+    "S23": {
+      "step": 5,
+      "name": "Action3"
+    },
+    "S24": {
+      "step": 5,
+      "name": "Action4"
+    },
+    "S25": {
+      "step": 5,
+      "name": "Action5"
+    }
+  },
+  "transitions": [
+    {
+      "sourceStateId": "S0",
+      "targetStateId": "S1",
+      "ruleName": "Action1"
+    },
+    {
+      "sourceStateId": "S0",
+      "targetStateId": "S2",
+      "ruleName": "Action2"
+    },
+    {
+      "sourceStateId": "S0",
+      "targetStateId": "S3",
+      "ruleName": "Action3"
+    },
+    {
+      "sourceStateId": "S0",
+      "targetStateId": "S4",
+      "ruleName": "Action4"
+    },
+    {
+      "sourceStateId": "S0",
+      "targetStateId": "S5",
+      "ruleName": "Action5"
+    },
+    {
+      "sourceStateId": "S1",
+      "targetStateId": "S6",
+      "ruleName": "Action1"
+    },
+    {
+      "sourceStateId": "S2",
+      "targetStateId": "S7",
+      "ruleName": "Action2"
+    },
+    {
+      "sourceStateId": "S3",
+      "targetStateId": "S8",
+      "ruleName": "Action3"
+    },
+    {
+      "sourceStateId": "S4",
+      "targetStateId": "S9",
+      "ruleName": "Action4"
+    },
+    {
+      "sourceStateId": "S5",
+      "targetStateId": "S10",
+      "ruleName": "Action5"
+    },
+    {
+      "sourceStateId": "S6",
+      "targetStateId": "S11",
+      "ruleName": "Action1"
+    },
+    {
+      "sourceStateId": "S7",
+      "targetStateId": "S12",
+      "ruleName": "Action2"
+    },
+    {
+      "sourceStateId": "S8",
+      "targetStateId": "S13",
+      "ruleName": "Action3"
+    },
+    {
+      "sourceStateId": "S9",
+      "targetStateId": "S14",
+      "ruleName": "Action4"
+    },
+    {
+      "sourceStateId": "S10",
+      "targetStateId": "S15",
+      "ruleName": "Action5"
+    },
+    {
+      "sourceStateId": "S11",
+      "targetStateId": "S16",
+      "ruleName": "Action1"
+    },
+    {
+      "sourceStateId": "S12",
+      "targetStateId": "S17",
+      "ruleName": "Action2"
+    },
+    {
+      "sourceStateId": "S13",
+      "targetStateId": "S18",
+      "ruleName": "Action3"
+    },
+    {
+      "sourceStateId": "S14",
+      "targetStateId": "S19",
+      "ruleName": "Action4"
+    },
+    {
+      "sourceStateId": "S15",
+      "targetStateId": "S20",
+      "ruleName": "Action5"
+    },
+    {
+      "sourceStateId": "S16",
+      "targetStateId": "S21",
+      "ruleName": "Action1"
+    },
+    {
+      "sourceStateId": "S17",
+      "targetStateId": "S22",
+      "ruleName": "Action2"
+    },
+    {
+      "sourceStateId": "S18",
+      "targetStateId": "S23",
+      "ruleName": "Action3"
+    },
+    {
+      "sourceStateId": "S19",
+      "targetStateId": "S24",
+      "ruleName": "Action4"
+    },
+    {
+      "sourceStateId": "S20",
+      "targetStateId": "S25",
+      "ruleName": "Action5"
+    }
+  ]
+}

--- a/src/StateMaker.Tests/sampledata/machine_loopback2_10deep.json
+++ b/src/StateMaker.Tests/sampledata/machine_loopback2_10deep.json
@@ -1,0 +1,130 @@
+{
+  "startingStateId": "S0",
+  "states": {
+    "S0": {
+      "step": 0
+    },
+    "S1": {
+      "step": 1
+    },
+    "S2": {
+      "step": 2
+    },
+    "S3": {
+      "step": 3
+    },
+    "S4": {
+      "step": 4
+    },
+    "S5": {
+      "step": 5
+    },
+    "S6": {
+      "step": 6
+    },
+    "S7": {
+      "step": 7
+    },
+    "S8": {
+      "step": 8
+    },
+    "S9": {
+      "step": 9
+    },
+    "S10": {
+      "step": 10
+    }
+  },
+  "transitions": [
+    {
+      "sourceStateId": "S0",
+      "targetStateId": "S1",
+      "ruleName": "advance"
+    },
+    {
+      "sourceStateId": "S1",
+      "targetStateId": "S2",
+      "ruleName": "advance"
+    },
+    {
+      "sourceStateId": "S2",
+      "targetStateId": "S3",
+      "ruleName": "advance"
+    },
+    {
+      "sourceStateId": "S2",
+      "targetStateId": "S0",
+      "ruleName": "loop back 2"
+    },
+    {
+      "sourceStateId": "S3",
+      "targetStateId": "S4",
+      "ruleName": "advance"
+    },
+    {
+      "sourceStateId": "S3",
+      "targetStateId": "S1",
+      "ruleName": "loop back 2"
+    },
+    {
+      "sourceStateId": "S4",
+      "targetStateId": "S5",
+      "ruleName": "advance"
+    },
+    {
+      "sourceStateId": "S4",
+      "targetStateId": "S2",
+      "ruleName": "loop back 2"
+    },
+    {
+      "sourceStateId": "S5",
+      "targetStateId": "S6",
+      "ruleName": "advance"
+    },
+    {
+      "sourceStateId": "S5",
+      "targetStateId": "S3",
+      "ruleName": "loop back 2"
+    },
+    {
+      "sourceStateId": "S6",
+      "targetStateId": "S7",
+      "ruleName": "advance"
+    },
+    {
+      "sourceStateId": "S6",
+      "targetStateId": "S4",
+      "ruleName": "loop back 2"
+    },
+    {
+      "sourceStateId": "S7",
+      "targetStateId": "S8",
+      "ruleName": "advance"
+    },
+    {
+      "sourceStateId": "S7",
+      "targetStateId": "S5",
+      "ruleName": "loop back 2"
+    },
+    {
+      "sourceStateId": "S8",
+      "targetStateId": "S9",
+      "ruleName": "advance"
+    },
+    {
+      "sourceStateId": "S8",
+      "targetStateId": "S6",
+      "ruleName": "loop back 2"
+    },
+    {
+      "sourceStateId": "S9",
+      "targetStateId": "S10",
+      "ruleName": "advance"
+    },
+    {
+      "sourceStateId": "S9",
+      "targetStateId": "S7",
+      "ruleName": "loop back 2"
+    }
+  ]
+}

--- a/src/StateMaker.Tests/sampledata/machine_loopback3_12deep.json
+++ b/src/StateMaker.Tests/sampledata/machine_loopback3_12deep.json
@@ -1,0 +1,151 @@
+{
+  "startingStateId": "S0",
+  "states": {
+    "S0": {
+      "step": 0
+    },
+    "S1": {
+      "step": 1
+    },
+    "S2": {
+      "step": 2
+    },
+    "S3": {
+      "step": 3
+    },
+    "S4": {
+      "step": 4
+    },
+    "S5": {
+      "step": 5
+    },
+    "S6": {
+      "step": 6
+    },
+    "S7": {
+      "step": 7
+    },
+    "S8": {
+      "step": 8
+    },
+    "S9": {
+      "step": 9
+    },
+    "S10": {
+      "step": 10
+    },
+    "S11": {
+      "step": 11
+    },
+    "S12": {
+      "step": 12
+    }
+  },
+  "transitions": [
+    {
+      "sourceStateId": "S0",
+      "targetStateId": "S1",
+      "ruleName": "advance"
+    },
+    {
+      "sourceStateId": "S1",
+      "targetStateId": "S2",
+      "ruleName": "advance"
+    },
+    {
+      "sourceStateId": "S2",
+      "targetStateId": "S3",
+      "ruleName": "advance"
+    },
+    {
+      "sourceStateId": "S3",
+      "targetStateId": "S4",
+      "ruleName": "advance"
+    },
+    {
+      "sourceStateId": "S3",
+      "targetStateId": "S0",
+      "ruleName": "loop back 3"
+    },
+    {
+      "sourceStateId": "S4",
+      "targetStateId": "S5",
+      "ruleName": "advance"
+    },
+    {
+      "sourceStateId": "S4",
+      "targetStateId": "S1",
+      "ruleName": "loop back 3"
+    },
+    {
+      "sourceStateId": "S5",
+      "targetStateId": "S6",
+      "ruleName": "advance"
+    },
+    {
+      "sourceStateId": "S5",
+      "targetStateId": "S2",
+      "ruleName": "loop back 3"
+    },
+    {
+      "sourceStateId": "S6",
+      "targetStateId": "S7",
+      "ruleName": "advance"
+    },
+    {
+      "sourceStateId": "S6",
+      "targetStateId": "S3",
+      "ruleName": "loop back 3"
+    },
+    {
+      "sourceStateId": "S7",
+      "targetStateId": "S8",
+      "ruleName": "advance"
+    },
+    {
+      "sourceStateId": "S7",
+      "targetStateId": "S4",
+      "ruleName": "loop back 3"
+    },
+    {
+      "sourceStateId": "S8",
+      "targetStateId": "S9",
+      "ruleName": "advance"
+    },
+    {
+      "sourceStateId": "S8",
+      "targetStateId": "S5",
+      "ruleName": "loop back 3"
+    },
+    {
+      "sourceStateId": "S9",
+      "targetStateId": "S10",
+      "ruleName": "advance"
+    },
+    {
+      "sourceStateId": "S9",
+      "targetStateId": "S6",
+      "ruleName": "loop back 3"
+    },
+    {
+      "sourceStateId": "S10",
+      "targetStateId": "S11",
+      "ruleName": "advance"
+    },
+    {
+      "sourceStateId": "S10",
+      "targetStateId": "S7",
+      "ruleName": "loop back 3"
+    },
+    {
+      "sourceStateId": "S11",
+      "targetStateId": "S12",
+      "ruleName": "advance"
+    },
+    {
+      "sourceStateId": "S11",
+      "targetStateId": "S8",
+      "ruleName": "loop back 3"
+    }
+  ]
+}

--- a/src/StateMaker/DeclarativeRule.cs
+++ b/src/StateMaker/DeclarativeRule.cs
@@ -27,7 +27,7 @@ public class DeclarativeRule : IRule
     public bool IsAvailable(State state)
     {
         var variables = GetNonNullableVariables(state);
-        return _evaluator.EvaluateBoolean(_condition, variables);
+        return _evaluator.EvaluateBooleanLenient(_condition, variables);
     }
 
     public State Execute(State state)

--- a/src/StateMaker/IExpressionEvaluator.cs
+++ b/src/StateMaker/IExpressionEvaluator.cs
@@ -4,4 +4,11 @@ public interface IExpressionEvaluator
 {
     bool EvaluateBoolean(string expression, Dictionary<string, object> variables);
     object Evaluate(string expression, Dictionary<string, object> variables);
+
+    /// <summary>
+    /// Evaluates a boolean expression, treating undefined parameters as null
+    /// instead of throwing. Used for rule conditions where some variables may
+    /// not yet exist in the state.
+    /// </summary>
+    bool EvaluateBooleanLenient(string expression, Dictionary<string, object> variables);
 }


### PR DESCRIPTION
## Summary
- Adds EvaluateBooleanLenient to IExpressionEvaluator that treats undefined parameters as null instead of throwing, using NCalc's EvaluateParameter event
- DeclarativeRule.IsAvailable now uses lenient evaluation so rules referencing variables not yet in the state are gracefully handled (e.g., name == 'Action1' returns false, buy != 'done' returns true when undefined)
- Strict EvaluateBoolean still throws for undefined params, preserving helpful error messages for typos in transformations and filter conditions
- Includes sample build/machine data files for various state machine topologies

## Test plan
- [x] 842 tests pass (7 new tests added)
- [x] Unit tests for EvaluateBooleanLenient: undefined equals (false), undefined not-equal (true), compound with undefined, all-defined, strict still throws
- [x] Unit tests for DeclarativeRule.IsAvailable: undefined equality, undefined inequality, defined state
- [x] Integration tests: rule referencing variable introduced by earlier rule, full cart scenario with order selected and buy transitions