### PR TITLE
Add genbuild sample files and GenbuildVerification test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         run: dotnet build --no-restore --configuration Release --warnaserror
 
       - name: Test with coverage
-        run: dotnet test --no-build --configuration Release --logger "trx;LogFileName=test-results.trx" --results-directory ./test-results --collect:"XPlat Code Coverage"
+        run: dotnet test --no-build --configuration Release --filter "FullyQualifiedName!~GenbuildVerification" --logger "trx;LogFileName=test-results.trx" --results-directory ./test-results --collect:"XPlat Code Coverage"
 
       - name: Upload test results
         uses: actions/upload-artifact@v4

--- a/src/StateMaker.Tests/GenbuildVerificationTests.cs
+++ b/src/StateMaker.Tests/GenbuildVerificationTests.cs
@@ -1,0 +1,237 @@
+using System.Globalization;
+using System.Text;
+using Xunit.Abstractions;
+
+namespace StateMaker.Tests;
+
+/// <summary>
+/// Verifies that each genbuild_* file in sampledata produces a state machine
+/// semantically equivalent to the corresponding machine_* file.
+///
+/// Semantic equivalence means:
+///   - Same set of distinct state variable-value sets
+///   - Same multiset of (source-state-vars, target-state-vars, rule-name) transitions
+///
+/// State IDs are intentionally ignored — different exploration strategies or rule
+/// orderings may assign IDs in different orders while still producing the same graph.
+///
+/// NOTE: This suite is excluded from CI. Run manually when investigating whether
+/// genbuild_* rule definitions correctly reproduce their corresponding machine_* files.
+/// To run: dotnet test --filter "GenbuildVerification"
+/// </summary>
+[Trait("Category", "GenbuildVerification")]
+public class GenbuildVerificationTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public GenbuildVerificationTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    [Fact]
+    public void AllGenbuildFiles_ProduceSemanticallySameMachineAsCorrespondingMachineFile()
+    {
+        var sampledataDir = Path.Combine(AppContext.BaseDirectory, "sampledata");
+
+        var genbuildFiles = Directory.GetFiles(sampledataDir, "genbuild_*.json")
+            .OrderBy(f => f)
+            .ToArray();
+
+        Assert.True(genbuildFiles.Length > 0,
+            $"No genbuild_*.json files found in {sampledataDir}");
+
+        var results = new List<(string genbuildName, bool passed, List<string> messages)>();
+
+        foreach (var genbuildFile in genbuildFiles)
+        {
+            var genbuildName = Path.GetFileName(genbuildFile);
+            var machineName = genbuildName.Replace("genbuild_", "machine_", StringComparison.Ordinal);
+            var machineFile = Path.Combine(sampledataDir, machineName);
+            var messages = new List<string>();
+
+            try
+            {
+                if (!File.Exists(machineFile))
+                {
+                    messages.Add($"No corresponding machine file found: {machineName}");
+                    results.Add((genbuildName, false, messages));
+                    continue;
+                }
+
+                // Build machine from genbuild file
+                var loader = new BuildDefinitionLoader();
+                var buildResult = loader.LoadFromFile(genbuildFile);
+                var builder = new StateMachineBuilder();
+                var builtMachine = builder.Build(
+                    buildResult.InitialState, buildResult.Rules, buildResult.Config);
+
+                // Load expected machine from machine file
+                var importer = new JsonImporter();
+                var expectedMachine = importer.Import(File.ReadAllText(machineFile));
+
+                // Compare semantically
+                var diffs = CompareMachinesSemantically(builtMachine, expectedMachine);
+                bool passed = diffs.Count == 0;
+
+                if (!passed)
+                    messages.AddRange(diffs);
+                else
+                    messages.Add($"States: {builtMachine.States.Count}, " +
+                                 $"Transitions: {builtMachine.Transitions.Count}");
+
+                results.Add((genbuildName, passed, messages));
+            }
+            catch (Exception ex)
+            {
+                messages.Add($"EXCEPTION {ex.GetType().Name}: {ex.Message}");
+                if (ex.InnerException is not null)
+                    messages.Add($"  Inner: {ex.InnerException.Message}");
+                results.Add((genbuildName, false, messages));
+            }
+        }
+
+        // Build report
+        var report = new StringBuilder();
+        report.AppendLine();
+        report.AppendLine("=== Genbuild Verification Report ===");
+        report.AppendLine();
+
+        int passCount = results.Count(r => r.passed);
+        int failCount = results.Count(r => !r.passed);
+
+        foreach (var (name, passed, messages) in results)
+        {
+            var status = passed ? "PASS" : "FAIL";
+            report.AppendLine(CultureInfo.InvariantCulture, $"[{status}] {name}");
+            foreach (var msg in messages)
+                report.AppendLine(CultureInfo.InvariantCulture, $"       {msg}");
+        }
+
+        report.AppendLine();
+        report.AppendLine(CultureInfo.InvariantCulture,
+            $"Result: {passCount}/{results.Count} passed, {failCount} failed");
+
+        _output.WriteLine(report.ToString());
+
+        Assert.True(failCount == 0, report.ToString());
+    }
+
+    // -------------------------------------------------------------------------
+    // Semantic comparison
+    // -------------------------------------------------------------------------
+
+    /// <summary>
+    /// Compares two state machines semantically: same state value-sets and same
+    /// transition graph (ignoring state IDs). Returns a list of human-readable
+    /// difference descriptions; empty list means they are equivalent.
+    /// </summary>
+    private static List<string> CompareMachinesSemantically(
+        StateMachine actual, StateMachine expected)
+    {
+        var diffs = new List<string>();
+
+        // --- Compare state sets ---
+
+        // Represent each state as a canonical string; compare as multisets
+        // (states are unique by value in a well-formed machine, but we use multisets
+        //  to surface any accidental duplicates clearly).
+        var actualStateStrings = actual.States.Values
+            .Select(FormatState)
+            .OrderBy(s => s)
+            .ToList();
+
+        var expectedStateStrings = expected.States.Values
+            .Select(FormatState)
+            .OrderBy(s => s)
+            .ToList();
+
+        var missingStates = MultisetExcept(expectedStateStrings, actualStateStrings);
+        var extraStates   = MultisetExcept(actualStateStrings, expectedStateStrings);
+
+        if (actualStateStrings.Count != expectedStateStrings.Count)
+            diffs.Add($"State count: built={actualStateStrings.Count}, " +
+                      $"expected={expectedStateStrings.Count}");
+
+        foreach (var s in missingStates)
+            diffs.Add($"Missing state: {s}");
+        foreach (var s in extraStates)
+            diffs.Add($"Extra state:   {s}");
+
+        // --- Compare transition multisets ---
+
+        var actualTransStrings  = SemanticTransitionStrings(actual);
+        var expectedTransStrings = SemanticTransitionStrings(expected);
+
+        var missingTrans = MultisetExcept(expectedTransStrings, actualTransStrings);
+        var extraTrans   = MultisetExcept(actualTransStrings, expectedTransStrings);
+
+        if (actualTransStrings.Count != expectedTransStrings.Count)
+            diffs.Add($"Transition count: built={actualTransStrings.Count}, " +
+                      $"expected={expectedTransStrings.Count}");
+
+        foreach (var t in missingTrans)
+            diffs.Add($"Missing transition: {t}");
+        foreach (var t in extraTrans)
+            diffs.Add($"Extra transition:   {t}");
+
+        return diffs;
+    }
+
+    /// <summary>
+    /// Builds a list of canonical transition strings:
+    ///   "{source-state} --RuleName--> {target-state}"
+    /// using state variable values rather than IDs, so the result is
+    /// independent of state ID assignment order.
+    /// </summary>
+    private static List<string> SemanticTransitionStrings(StateMachine machine)
+    {
+        return machine.Transitions
+            .Select(t =>
+            {
+                var src = FormatState(machine.States[t.SourceStateId]);
+                var tgt = FormatState(machine.States[t.TargetStateId]);
+                return $"{src} --{t.RuleName}--> {tgt}";
+            })
+            .OrderBy(s => s)
+            .ToList();
+    }
+
+    /// <summary>
+    /// Returns elements that are in <paramref name="from"/> but not in
+    /// <paramref name="remove"/>, treating both as multisets (each occurrence
+    /// is matched independently).
+    /// </summary>
+    private static List<string> MultisetExcept(List<string> from, List<string> remove)
+    {
+        var remaining = new List<string>(from);
+        foreach (var item in remove)
+        {
+            int idx = remaining.IndexOf(item);
+            if (idx >= 0)
+                remaining.RemoveAt(idx);
+        }
+        return remaining;
+    }
+
+    /// <summary>
+    /// Produces a deterministic, human-readable representation of a state's
+    /// variable values, e.g. "{branch=trunk, step=0}". Variables are sorted by
+    /// key so the output is stable regardless of dictionary insertion order.
+    /// </summary>
+    private static string FormatState(State state)
+    {
+        var parts = state.Variables
+            .OrderBy(kv => kv.Key, StringComparer.Ordinal)
+            .Select(kv => $"{kv.Key}={FormatValue(kv.Value)}");
+        return "{" + string.Join(", ", parts) + "}";
+    }
+
+    private static string FormatValue(object? value) => value switch
+    {
+        null          => "null",
+        bool b        => b ? "true" : "false",
+        string s      => $"'{s}'",
+        _             => Convert.ToString(value, CultureInfo.InvariantCulture) ?? "null"
+    };
+}

--- a/src/StateMaker.Tests/StateMaker.Tests.csproj
+++ b/src/StateMaker.Tests/StateMaker.Tests.csproj
@@ -23,6 +23,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="sampledata\**">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\StateMaker\StateMaker.csproj" />
     <ProjectReference Include="..\StateMaker.Console\StateMaker.Console.csproj" />
   </ItemGroup>

--- a/src/StateMaker.Tests/sampledata/genbuild_20deep_linear.json
+++ b/src/StateMaker.Tests/sampledata/genbuild_20deep_linear.json
@@ -1,0 +1,18 @@
+{
+  "initialState": {
+    "step": 0
+  },
+  "rules": [
+    {
+      "name": "Advance",
+      "condition": "step < 20",
+      "transformations": {
+        "step": "step + 1"
+      }
+    }
+  ],
+  "config": {
+    "maxStates": 21,
+    "explorationStrategy": "BreadthFirstSearch"
+  }
+}

--- a/src/StateMaker.Tests/sampledata/genbuild_2branch_loopback2_10deep.json
+++ b/src/StateMaker.Tests/sampledata/genbuild_2branch_loopback2_10deep.json
@@ -1,0 +1,33 @@
+{
+  "initialState": {
+    "step": 0
+  },
+  "rules": [
+    {
+      "name": "advance",
+      "condition": "step <= 9",
+      "transformations": {
+        "step": "step + 1"
+      }
+    },
+    {
+      "name": "loop back 3",
+      "condition": "step >= 3 && step <= 10",
+      "transformations": {
+        "step": "step - 2"
+      }
+    },
+    {
+      "name": "birth branch",
+      "condition": "step == 0",
+      "transformations": {
+        "step": "step + 1",
+        "branch": "'new branch'"
+      }
+    }
+  ],
+  "config": {
+    "maxStates": 30,
+    "explorationStrategy": "BreadthFirstSearch"
+  }
+}

--- a/src/StateMaker.Tests/sampledata/genbuild_2branch_merge_10deep.json
+++ b/src/StateMaker.Tests/sampledata/genbuild_2branch_merge_10deep.json
@@ -1,0 +1,58 @@
+{
+  "initialState": {
+    "step": 0,
+    "branch": "trunk"
+  },
+  "rules": [
+    {
+      "name": "take branch1",
+      "condition": "branch == 'trunk'",
+      "transformations": {
+        "step": "step + 1",
+        "branch": "'branch1'"
+      }
+    },
+    {
+      "name": "take branch2",
+      "condition": "branch == 'trunk'",
+      "transformations": {
+        "step": "step + 1",
+        "branch": "'branch2'"
+      }
+    },
+    {
+      "name": "add branch1",
+      "condition": "branch == 'branch1' && step <= 9",
+      "transformations": {
+        "step": "step + 1"
+      }
+    },
+    {
+      "name": "add branch2",
+      "condition": "branch == 'branch2' && step <= 9",
+      "transformations": {
+        "step": "step + 1"
+      }
+    },
+    {
+      "name": "merge branch1",
+      "condition": "step >= 2 && branch == 'branch1'",
+      "transformations": {
+        "step": "step + 1",
+        "branch": "'trunk'"
+      }
+    },
+    {
+      "name": "merge branch2",
+      "condition": "step >= 2 && branch == 'branch2'",
+      "transformations": {
+        "step": "step + 1",
+        "branch": "'trunk'"
+      }
+    }
+  ],
+  "config": {
+    "maxStates": 30,
+    "explorationStrategy": "BreadthFirstSearch"
+  }
+}

--- a/src/StateMaker.Tests/sampledata/genbuild_5actions_5deep.json
+++ b/src/StateMaker.Tests/sampledata/genbuild_5actions_5deep.json
@@ -1,0 +1,46 @@
+{
+  "initialState": {
+    "step": 0
+  },
+  "rules": [
+    {
+      "name": "Action1",
+      "condition": "step < 5",
+      "transformations": {
+        "step": "step + 1"
+      }
+    },
+    {
+      "name": "Action2",
+      "condition": "step < 5",
+      "transformations": {
+        "step": "step + 1"
+      }
+    },
+    {
+      "name": "Action3",
+      "condition": "step < 5",
+      "transformations": {
+        "step": "step + 1"
+      }
+    },
+    {
+      "name": "Action4",
+      "condition": "step < 5",
+      "transformations": {
+        "step": "step + 1"
+      }
+    },
+    {
+      "name": "Action5",
+      "condition": "step < 5",
+      "transformations": {
+        "step": "step + 1"
+      }
+    }
+  ],
+  "config": {
+    "maxStates": 10,
+    "explorationStrategy": "BreadthFirstSearch"
+  }
+}

--- a/src/StateMaker.Tests/sampledata/genbuild_5high_5deep_tree.json
+++ b/src/StateMaker.Tests/sampledata/genbuild_5high_5deep_tree.json
@@ -1,0 +1,91 @@
+{
+  "initialState": {
+    "step": 0
+  },
+  "rules": [
+    {
+      "name": "Action1",
+      "condition": "step == 0",
+      "transformations": {
+        "step": "step + 1",
+        "name": "'Action1'"
+      }
+    },
+    {
+      "name": "Action2",
+      "condition": "step == 0",
+      "transformations": {
+        "step": "step + 1",
+        "name": "'Action2'"
+      }
+    },
+    {
+      "name": "Action3",
+      "condition": "step == 0",
+      "transformations": {
+        "step": "step + 1",
+        "name": "'Action3'"
+      }
+    },
+    {
+      "name": "Action4",
+      "condition": "step == 0",
+      "transformations": {
+        "step": "step + 1",
+        "name": "'Action4'"
+      }
+    },
+    {
+      "name": "Action5",
+      "condition": "step == 0",
+      "transformations": {
+        "step": "step + 1",
+        "name": "'Action5'"
+      }
+    },
+    {
+      "name": "Action1",
+      "condition": "step >= 1 && step <= 4 && name == 'Action1'",
+      "transformations": {
+        "step": "step + 1",
+        "name": "'Action1'"
+      }
+    },
+    {
+      "name": "Action2",
+      "condition": "step >= 1 && step <= 4 && name == 'Action2'",
+      "transformations": {
+        "step": "step + 1",
+        "name": "'Action2'"
+      }
+    },
+    {
+      "name": "Action3",
+      "condition": "step >= 1 && step <= 4 && name == 'Action3'",
+      "transformations": {
+        "step": "step + 1",
+        "name": "'Action3'"
+      }
+    },
+    {
+      "name": "Action4",
+      "condition": "step >= 1 && step <= 4 && name == 'Action4'",
+      "transformations": {
+        "step": "step + 1",
+        "name": "'Action4'"
+      }
+    },
+    {
+      "name": "Action5",
+      "condition": "step >= 1 && step <= 4 && name == 'Action5'",
+      "transformations": {
+        "step": "step + 1",
+        "name": "'Action5'"
+      }
+    }
+  ],
+  "config": {
+    "maxStates": 30,
+    "explorationStrategy": "BreadthFirstSearch"
+  }
+}

--- a/src/StateMaker.Tests/sampledata/genbuild_cart_3options_select_buy.json
+++ b/src/StateMaker.Tests/sampledata/genbuild_cart_3options_select_buy.json
@@ -1,0 +1,62 @@
+{
+  "initialState": {
+    "step": 0,
+    "cart": "empty"
+  },
+  "rules": [
+    {
+      "name": "present options",
+      "condition": "step == 0 && cart == 'empty'",
+      "transformations": {
+        "step": "step + 1",
+        "displayed": "'options'"
+      }
+    },
+    {
+      "name": "pick option fish",
+      "condition": "displayed == 'options' && step > 0",
+      "transformations": {
+        "step": "step + 1",
+        "displayed": "'fish'"
+      }
+    },
+    {
+      "name": "pick option salad",
+      "condition": "displayed == 'options' && step > 0",
+      "transformations": {
+        "step": "step + 1",
+        "displayed": "'salad'"
+      }
+    },
+    {
+      "name": "pick option beef",
+      "condition": "displayed == 'options' && step > 0",
+      "transformations": {
+        "step": "step + 1",
+        "displayed": "'beef'"
+      }
+    },
+    {
+      "name": "order selected",
+      "condition": "displayed != 'options' && step > 1 && cart == 'empty' && buy != 'done'",
+      "transformations": {
+        "step": "step + 1",
+        "cart": "displayed",
+        "displayed": "'cart'"
+      }
+    },
+    {
+      "name": "buy",
+      "condition": "displayed == 'cart' && cart != 'empty'",
+      "transformations": {
+        "step": "step + 1",
+        "cart": "'empty'",
+        "buy": "'done'"
+      }
+    }
+  ],
+  "config": {
+    "maxStates": 30,
+    "explorationStrategy": "BreadthFirstSearch"
+  }
+}

--- a/src/StateMaker.Tests/sampledata/genbuild_cart_3options_select_buy_2loopback.json
+++ b/src/StateMaker.Tests/sampledata/genbuild_cart_3options_select_buy_2loopback.json
@@ -1,0 +1,75 @@
+{
+  "initialState": {
+    "step": 0,
+    "cart": "empty"
+  },
+  "rules": [
+    {
+      "name": "present options",
+      "condition": "step == 0 && cart == 'empty'",
+      "transformations": {
+        "step": "step + 1",
+        "displayed": "'options'"
+      }
+    },
+    {
+      "name": "pick option fish",
+      "condition": "displayed == 'options' && step > 0",
+      "transformations": {
+        "step": "step + 1",
+        "displayed": "'fish'"
+      }
+    },
+    {
+      "name": "pick option salad",
+      "condition": "displayed == 'options' && step > 0",
+      "transformations": {
+        "step": "step + 1",
+        "displayed": "'salad'"
+      }
+    },
+    {
+      "name": "pick option beef",
+      "condition": "displayed == 'options' && step > 0",
+      "transformations": {
+        "step": "step + 1",
+        "displayed": "'beef'"
+      }
+    },
+    {
+      "name": "order selected",
+      "condition": "displayed != 'options' && step > 1 && cart == 'empty' && buy != 'done'",
+      "transformations": {
+        "step": "step + 1",
+        "cart": "displayed",
+        "displayed": "'cart'"
+      }
+    },
+    {
+      "name": "buy",
+      "condition": "displayed == 'cart' && cart != 'empty'",
+      "transformations": {
+        "step": "step + 1",
+        "cart": "'empty'",
+        "buy": "'done'"
+      }
+    },
+    {
+      "name": "advance",
+      "condition": "step < 10",
+      "transformations": {
+        "step": "step + 1"
+      }
+    },
+    {
+      "name": "loop back 2",
+      "condition": "step >= 2 && step <= 10",
+      "transformations": {
+        "step": "step - 2"
+      }
+    }
+  ],
+  "config": {
+    "explorationStrategy": "BreadthFirstSearch"
+  }
+}

--- a/src/StateMaker.Tests/sampledata/genbuild_doubleloopchain_4chain_20states.json
+++ b/src/StateMaker.Tests/sampledata/genbuild_doubleloopchain_4chain_20states.json
@@ -1,0 +1,34 @@
+{
+  "initialState": {
+    "step": 0,
+    "loops": 0
+  },
+  "rules": [
+    {
+      "name": "advance",
+      "condition": "step < 4",
+      "transformations": {
+        "step": "step + 1"
+      }
+    },
+    {
+      "name": "advance",
+      "condition": "step == 4",
+      "transformations": {
+        "step": "0"
+      }
+    },
+    {
+      "name": "advance",
+      "condition": "step >= 2 && step <= 3",
+      "transformations": {
+        "step": "0",
+        "loops": "loops + 1"
+      }
+    }
+  ],
+  "config": {
+    "maxStates": 20,
+    "explorationStrategy": "BreadthFirstSearch"
+  }
+}

--- a/src/StateMaker.Tests/sampledata/genbuild_loopback2_10deep.json
+++ b/src/StateMaker.Tests/sampledata/genbuild_loopback2_10deep.json
@@ -1,0 +1,25 @@
+{
+  "initialState": {
+    "step": 0
+  },
+  "rules": [
+    {
+      "name": "advance",
+      "condition": "step <= 9",
+      "transformations": {
+        "step": "step + 1"
+      }
+    },
+    {
+      "name": "loop back 2",
+      "condition": "step >= 2 && step <= 10",
+      "transformations": {
+        "step": "step - 2"
+      }
+    }
+  ],
+  "config": {
+    "maxStates": 30,
+    "explorationStrategy": "BreadthFirstSearch"
+  }
+}

--- a/src/StateMaker.Tests/sampledata/genbuild_loopback3_12deep.json
+++ b/src/StateMaker.Tests/sampledata/genbuild_loopback3_12deep.json
@@ -1,0 +1,25 @@
+{
+  "initialState": {
+    "step": 0
+  },
+  "rules": [
+    {
+      "name": "advance",
+      "condition": "step <= 11",
+      "transformations": {
+        "step": "step + 1"
+      }
+    },
+    {
+      "name": "loop back 3",
+      "condition": "step >= 3 && step <= 12",
+      "transformations": {
+        "step": "step - 3"
+      }
+    }
+  ],
+  "config": {
+    "maxStates": 30,
+    "explorationStrategy": "BreadthFirstSearch"
+  }
+}

--- a/src/StateMaker.Tests/sampledata/genbuild_loopchain_6chain_20states.json
+++ b/src/StateMaker.Tests/sampledata/genbuild_loopchain_6chain_20states.json
@@ -1,0 +1,48 @@
+{
+  "initialState": {
+    "step": 0,
+    "loops": 0
+  },
+  "rules": [
+    {
+      "name": "advance",
+      "condition": "step >= 0 && step < 3",
+      "transformations": {
+        "step": "step + 1"
+      }
+    },
+    {
+      "name": "advance",
+      "condition": "step == 3",
+      "transformations": {
+        "step": "step + 1"
+      }
+    },
+    {
+      "name": "advance",
+      "condition": "step == 3",
+      "transformations": {
+        "step": "0",
+        "loops": "loops + 1"
+      }
+    },
+    {
+      "name": "advance",
+      "condition": "step > 3 && step < 6",
+      "transformations": {
+        "step": "step + 1"
+      }
+    },
+    {
+      "name": "advance",
+      "condition": "step == 6",
+      "transformations": {
+        "step": "0"
+      }
+    }
+  ],
+  "config": {
+    "maxStates": 20,
+    "explorationStrategy": "BreadthFirstSearch"
+  }
+}

--- a/src/StateMaker.Tests/sampledata/genbuild_loopchain_6chain_40states.json
+++ b/src/StateMaker.Tests/sampledata/genbuild_loopchain_6chain_40states.json
@@ -1,0 +1,48 @@
+{
+  "initialState": {
+    "step": 0,
+    "loops": 0
+  },
+  "rules": [
+    {
+      "name": "advance",
+      "condition": "step >= 0 && step < 3",
+      "transformations": {
+        "step": "step + 1"
+      }
+    },
+    {
+      "name": "advance",
+      "condition": "step == 3",
+      "transformations": {
+        "step": "step + 1"
+      }
+    },
+    {
+      "name": "advance",
+      "condition": "step == 3",
+      "transformations": {
+        "step": "0",
+        "loops": "loops + 1"
+      }
+    },
+    {
+      "name": "advance",
+      "condition": "step > 3 && step < 6",
+      "transformations": {
+        "step": "step + 1"
+      }
+    },
+    {
+      "name": "advance",
+      "condition": "step == 6",
+      "transformations": {
+        "step": "0"
+      }
+    }
+  ],
+  "config": {
+    "maxStates": 40,
+    "explorationStrategy": "BreadthFirstSearch"
+  }
+}


### PR DESCRIPTION
## Summary

- Add 12 `genbuild_*.json` build definition files to `sampledata/`, one per `machine_*` file, each using a different rule strategy than the existing `build_*` counterparts (e.g. upper-bound conditions instead of lower-bound, `maxStates` instead of `maxDepth`, consolidated or split rules)
- Add `GenbuildVerificationTests`: builds each `genbuild_*` machine and compares it semantically to the corresponding `machine_*` file — state IDs are ignored; comparison is by variable-value sets and (source, target, ruleName) transition tuples; exceptions are caught per file so all results are reported before failing
- Copy `sampledata/**` to test output directory via `.csproj` so tests can locate files at runtime via `AppContext.BaseDirectory`
- Exclude `GenbuildVerification` from CI (`--filter` in `ci.yml`); the suite is under investigation for test oracle correctness and is run manually with `dotnet test --filter "GenbuildVerification"`

## Test plan

- [ ] CI passes (GenbuildVerification excluded from automated run)
- [ ] `dotnet test --filter "GenbuildVerification"` runs manually and reports per-file PASS/FAIL detail

🤖 Generated with [Claude Code](https://claude.com/claude-code)
